### PR TITLE
fix: Updated logic for edge case where there is only 1 spine index item.

### DIFF
--- a/src/activity/reader/Epub/EpubActivity.cpp
+++ b/src/activity/reader/Epub/EpubActivity.cpp
@@ -647,7 +647,8 @@ bool EpubActivity::slowPath() {
   vTaskDelay(pdMS_TO_TICKS(50));
 
   ensureThumbnailExists();
-  currentSpineIndex = epub->getSpineIndexForInitialOpen() != 0 ? epub->getSpineIndexForInitialOpen() : 1;
+  const int initialSpine = epub->getSpineIndexForInitialOpen();
+  currentSpineIndex = (initialSpine == 0 && epub->getSpineItemsCount() > 1) ? 1 : initialSpine;
   nextPageNumber = 0;
 
   FontManager::ensureReaderLayoutFonts(calculateViewport().fontId, renderer);
@@ -1272,7 +1273,7 @@ void EpubActivity::deleteProgress() {
   APP_STATE.lastRead = "";
   APP_STATE.saveToFile();
 
-  int newSpineIndex = 1;
+  const int newSpineIndex = epub->getSpineItemsCount() > 1 ? 1 : 0;
 
   if (currentSpine != newSpineIndex || currentPage != 0) {
     currentSpineIndex = newSpineIndex;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
Fixed a "cannot read chapter" error when opening epubs created with "Send to Xteink" browser extension. Bug is caused by edge case where the epub only has one spine item at index 0, but current logic defaults to start at spine index 1.
* **What changes are included?**
Added edge case that defaults to spine index 0 in cases where there is only 1 spine index item.

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While Inx doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES | PARTIALLY | NO >**_
Yes. Claude was fully used to help identify the bug and propose the updated code.
