### PR TITLE
fix: restore simulator build on 1.0.16

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -319,6 +319,14 @@ void GfxRenderer::copyGrayscaleMsbBuffers() const { display.copyGrayscaleMsbBuff
 
 void GfxRenderer::displayGrayBuffer(const bool quality) const { display.displayGrayBuffer(quality); }
 
+void GfxRenderer::displayTextGrayBuffer() const {
+#ifdef SIMULATOR
+  display.displayGrayBuffer(false);
+#else
+  display.displayTextGrayBuffer();
+#endif
+}
+
 void GfxRenderer::displayGrayBufferFastQuality() const {
 #ifdef SIMULATOR
   display.displayGrayBuffer(false);

--- a/src/activity/reader/Epub/StatusBar.cpp
+++ b/src/activity/reader/Epub/StatusBar.cpp
@@ -333,7 +333,11 @@ std::string StatusBar::getPercentString(float bookProgress) const {
  */
 std::string StatusBar::getBatteryPercentString() const {
     char buffer[16];
+#ifdef SIMULATOR
+    snprintf(buffer, sizeof(buffer), "100%%");
+#else
     snprintf(buffer, sizeof(buffer), "%d%%", gpio.getBatteryPercentage());
+#endif
     return std::string(buffer);
 }
 

--- a/src/simulator/SimulatorCompat.h
+++ b/src/simulator/SimulatorCompat.h
@@ -45,6 +45,12 @@ inline TickType_t xTaskGetTickCount() {
   static const steady_clock::time_point start = steady_clock::now();
   return static_cast<TickType_t>(duration_cast<milliseconds>(steady_clock::now() - start).count());
 }
+
+inline uint32_t esp_random() {
+  static uint32_t state = 0x9e3779b9U;
+  state = state * 1664525U + 1013904223U + xTaskGetTickCount();
+  return state;
+}
 #endif
 
 #ifndef MANUAL_REFRESH


### PR DESCRIPTION
## Summary

* Fixes the full SDL simulator build on `release/1.0.16`.
* Uses a simulator-only fallback for the EPUB status bar battery percentage.
* Adds a simulator-compatible `esp_random()` shim for the sleep image shuffle seed.
* Maps text grayscale display through the simulator-supported grayscale refresh path.
* Keeps real firmware builds using the hardware HAL methods.

## Additional Context

The CrossPoint simulator HAL does not expose every ESP32/display method used by the current 1.0.16 firmware path. The status bar battery percentage, sleep image shuffle seed, and text grayscale display path each needed small simulator-safe compatibility handling.

The battery fallback matches the existing simulator behavior used by `ScreenComponents::drawBattery()`.

## Testing

* `python3 scripts/build_html.py`
* `/tmp/inx-pio-venv/bin/pio run -e simulator`
* `/tmp/inx-pio-venv/bin/pio run -e simulator_web`
* `/tmp/inx-pio-venv/bin/pio run`
* `git diff --check`

---

### AI Usage

While Inx doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? **PARTIALLY**
