### PR TITLE
feat: add Page Numbers + Percentage status bar option

### DIFF
--- a/src/activity/reader/Epub/SettingsDrawer.cpp
+++ b/src/activity/reader/Epub/SettingsDrawer.cpp
@@ -553,7 +553,7 @@ void SettingsDrawer::setupMenu() {
     };
     statusLeftEntry.change = [](BookSettings& s, int delta) {
       int newVal = static_cast<int>(s.statusBarLeft.item) + delta;
-      if (newVal >= 0 && newVal <= static_cast<int>(StatusBarItem::AUTHOR_NAME)) {
+      if (newVal >= 0 && newVal < static_cast<int>(StatusBarItem::STATUS_BAR_ITEM_COUNT)) {
         s.statusBarLeft.item = static_cast<StatusBarItem>(newVal);
         s.useCustomSettings = true;
       }
@@ -569,7 +569,7 @@ void SettingsDrawer::setupMenu() {
     };
     statusMiddleEntry.change = [](BookSettings& s, int delta) {
       int newVal = static_cast<int>(s.statusBarMiddle.item) + delta;
-      if (newVal >= 0 && newVal <= static_cast<int>(StatusBarItem::AUTHOR_NAME)) {
+      if (newVal >= 0 && newVal < static_cast<int>(StatusBarItem::STATUS_BAR_ITEM_COUNT)) {
         s.statusBarMiddle.item = static_cast<StatusBarItem>(newVal);
         s.useCustomSettings = true;
       }
@@ -585,7 +585,7 @@ void SettingsDrawer::setupMenu() {
     };
     statusRightEntry.change = [](BookSettings& s, int delta) {
       int newVal = static_cast<int>(s.statusBarRight.item) + delta;
-      if (newVal >= 0 && newVal <= static_cast<int>(StatusBarItem::AUTHOR_NAME)) {
+      if (newVal >= 0 && newVal < static_cast<int>(StatusBarItem::STATUS_BAR_ITEM_COUNT)) {
         s.statusBarRight.item = static_cast<StatusBarItem>(newVal);
         s.useCustomSettings = true;
       }
@@ -603,9 +603,10 @@ void SettingsDrawer::setupMenu() {
 const char* SettingsDrawer::getStatusBarItemName(StatusBarItem item) {
   static const char* names[] = {"None",           "Page Numbers", "Percentage",     "Chapter Title",
                                 "Battery Icon",   "Battery %",    "Battery Icon+%", "Progress Bar",
-                                "Progress Bar+%", "Page Bars",    "Book Title",     "Author Name"};
+                                "Progress Bar+%", "Page Bars",    "Book Title",     "Author Name",
+                                "Page Num+%"};
   int index = static_cast<int>(item);
-  if (index > static_cast<int>(StatusBarItem::AUTHOR_NAME)) {
+  if (index < 0 || index >= static_cast<int>(StatusBarItem::STATUS_BAR_ITEM_COUNT)) {
     index = 0;
   }
   return names[index];

--- a/src/activity/reader/Epub/StatusBar.cpp
+++ b/src/activity/reader/Epub/StatusBar.cpp
@@ -227,13 +227,23 @@ void StatusBar::renderSection(int position, int sectionStart, int sectionCenter,
         case StatusBarItem::AUTHOR_NAME: {
             std::string author = m_epub.getAuthor();
             int maxWidth = sectionWidth - 10;
-            std::string truncated = m_renderer.text.truncate(ATKINSON_HYPERLEGIBLE_8_FONT_ID, 
+            std::string truncated = m_renderer.text.truncate(ATKINSON_HYPERLEGIBLE_8_FONT_ID,
                                                           author.c_str(), maxWidth);
             int xPos = getPositionX(truncated.c_str());
             m_renderer.text.render(ATKINSON_HYPERLEGIBLE_8_FONT_ID, xPos, textY, truncated.c_str());
             break;
         }
-            
+
+        case StatusBarItem::PAGE_NUMBERS_WITH_PERCENT: {
+            std::string combined = pageStr + " " + percentStr;
+            int maxWidth = sectionWidth - 10;
+            std::string truncated = m_renderer.text.truncate(ATKINSON_HYPERLEGIBLE_8_FONT_ID,
+                                                          combined.c_str(), maxWidth);
+            int xPos = getPositionX(truncated.c_str());
+            m_renderer.text.render(ATKINSON_HYPERLEGIBLE_8_FONT_ID, xPos, textY, truncated.c_str());
+            break;
+        }
+
         default:
             break;
     }

--- a/src/activity/settings/ReaderPresetEditorActivity.cpp
+++ b/src/activity/settings/ReaderPresetEditorActivity.cpp
@@ -54,6 +54,8 @@ const char* statusPlaceholder(StatusBarItem item) {
       return "The Example Book";
     case StatusBarItem::AUTHOR_NAME:
       return "Jane Author";
+    case StatusBarItem::PAGE_NUMBERS_WITH_PERCENT:
+      return "12/340 45%";
     case StatusBarItem::NONE:
     default:
       return "";

--- a/src/state/BookSetting.h
+++ b/src/state/BookSetting.h
@@ -29,6 +29,7 @@ enum class StatusBarItem {
   PAGE_BARS,                  ///< Vertical bars representing pages
   BOOK_TITLE,                 ///< Book title
   AUTHOR_NAME,                ///< Author name
+  PAGE_NUMBERS_WITH_PERCENT,  ///< Page numbers and percentage combined (e.g., "12/340 45%")
   STATUS_BAR_ITEM_COUNT
 };
 

--- a/src/state/SystemSetting.h
+++ b/src/state/SystemSetting.h
@@ -102,6 +102,7 @@ public:
         STATUS_ITEM_PAGE_BARS = 9,                  ///< Page bars
         STATUS_ITEM_BOOK_TITLE = 10,                ///< Book title
         STATUS_ITEM_AUTHOR_NAME = 11,               ///< Author name
+        STATUS_ITEM_PAGE_NUMBERS_WITH_PERCENT = 12, ///< Page numbers and percentage combined (e.g., "12/340 45%")
         STATUS_BAR_ITEM_COUNT
     };
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Adds a new status bar option that displays page number and reading percentage together (e.g. `12/340 45%`), available in the left, middle, and right status bar sections.
* **What changes are included?**
  - `src/state/BookSetting.h` — new `PAGE_NUMBERS_WITH_PERCENT` value in `StatusBarItem` enum
  - `src/state/SystemSetting.h` — matching `STATUS_ITEM_PAGE_NUMBERS_WITH_PERCENT = 12` in the legacy enum
  - `src/activity/reader/Epub/StatusBar.cpp` — render case combining page string and percent string
  - `src/activity/reader/Epub/SettingsDrawer.cpp` — display name `"Page Num+%"` and updated bounds checks to use `< STATUS_BAR_ITEM_COUNT`
  - `src/activity/settings/ReaderPresetEditorActivity.cpp` — preview placeholder `"12/340 45%"`

## Additional Context

* The new enum value is appended at position 12 (after `AUTHOR_NAME`) to preserve backward compatibility with existing `settings.bin` saves — no existing user settings will be affected.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_