### PR TITLE
Add hide button hints toggle and EPUB reading guide lines

### DIFF
--- a/src/activity/Menu.h
+++ b/src/activity/Menu.h
@@ -58,7 +58,9 @@ class Menu {
 
   void renderButtonHints(const GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
                          const char* btn4) const {
-    INX_THEME.drawButtonHints(renderer, ATKINSON_HYPERLEGIBLE_10_FONT_ID, btn1, btn2, btn3, btn4);
+    if (!SETTINGS.hideButtonHints) {
+      INX_THEME.drawButtonHints(renderer, ATKINSON_HYPERLEGIBLE_10_FONT_ID, btn1, btn2, btn3, btn4);
+    }
     if (INX_THEME.mainTabsAtBottom()) {
       renderTabBar(renderer);
     }

--- a/src/activity/page/SettingsActivity.cpp
+++ b/src/activity/page/SettingsActivity.cpp
@@ -47,6 +47,8 @@ std::vector<SettingInfo> buildSystemPageSettings(const bool x3) {
   settings.push_back(
       SettingInfo::Enum("Library Mode", &SystemSetting::libraryMode, {"List", "Grid"}, GroupType::DEVICE_DISPLAY));
   settings.push_back(SettingInfo::Toggle("Shelf mode", &SystemSetting::libraryShelfEnabled, GroupType::DEVICE_DISPLAY));
+  settings.push_back(
+      SettingInfo::Toggle("Hide button hints", &SystemSetting::hideButtonHints, GroupType::DEVICE_DISPLAY));
   settings.push_back(SettingInfo::Value("Recent books shown", &SystemSetting::recentVisibleCount, {1, 9, 1},
                                         GroupType::DEVICE_DISPLAY));
 

--- a/src/activity/reader/Epub/EpubActivity.cpp
+++ b/src/activity/reader/Epub/EpubActivity.cpp
@@ -1765,6 +1765,9 @@ void EpubActivity::renderContents(std::unique_ptr<Page> page, const int oriented
   page->render(renderer, fontId, headerFontId, orientedMarginLeft, orientedMarginTop, skipImagesInPageRender, imageMode,
                /*skipOnlyGrayscaleImages=*/highQuality && !deferOneBitImageRender);
 
+  // Overlay before storeBwBuffer so guide lines are preserved through AA/grayscale passes.
+  drawReadingGuideLines(orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
+
   renderStatusBar(orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
   if (isCurrentPageBookmarked()) {
     drawBookmarkIndicator();
@@ -1870,6 +1873,7 @@ void EpubActivity::renderContents(std::unique_ptr<Page> page, const int oriented
     renderer.clearScreen();
     page->render(renderer, fontId, headerFontId, orientedMarginLeft, orientedMarginTop, /*skipImages=*/true,
                  ImageRenderMode::OneBit, /*skipOnlyGrayscaleImages=*/true);
+    drawReadingGuideLines(orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
     renderStatusBar(orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
     if (isCurrentPageBookmarked()) {
       drawBookmarkIndicator();
@@ -1897,6 +1901,27 @@ void EpubActivity::renderStatusBar(const int orientedMarginRight, const int orie
   if (statusBar && section) {
     statusBar->render(section.get(), currentSpineIndex, orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
   }
+}
+
+void EpubActivity::drawReadingGuideLines(const int orientedMarginTop, const int orientedMarginRight,
+                                         const int orientedMarginBottom, const int orientedMarginLeft) const {
+  if (!READER_SETTINGS.readingGuideLinesEnabled) {
+    return;
+  }
+  const int contentWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;
+  if (contentWidth < 3) {
+    return;
+  }
+  const int lineTop = orientedMarginTop;
+  const int lineBottom = renderer.getScreenHeight() - orientedMarginBottom;
+  if (lineBottom <= lineTop) {
+    return;
+  }
+  const int x1 = orientedMarginLeft + contentWidth / 3;
+  const int x2 = orientedMarginLeft + (contentWidth * 2) / 3;
+  // Dotted so the guides cue fixation without fighting body text on e-ink.
+  renderer.line.render(x1, lineTop, x1, lineBottom, true, LineRender::Style::Dotted);
+  renderer.line.render(x2, lineTop, x2, lineBottom, true, LineRender::Style::Dotted);
 }
 
 /**

--- a/src/activity/reader/Epub/EpubActivity.h
+++ b/src/activity/reader/Epub/EpubActivity.h
@@ -177,6 +177,13 @@ class EpubActivity final : public ActivityWithSubactivity {
   void renderStatusBar(int orientedMarginRight, int orientedMarginBottom, int orientedMarginLeft) const;
 
   /**
+   * Draws vertical reading-guide lines at 1/3 and 2/3 of the content width when enabled.
+   * Pure overlay — does not affect layout or page cache.
+   */
+  void drawReadingGuideLines(int orientedMarginTop, int orientedMarginRight, int orientedMarginBottom,
+                             int orientedMarginLeft) const;
+
+  /**
    * Saves current reading progress to file using BookProgress handler.
    *
    * @param spineIndex Current spine index

--- a/src/activity/reader/Epub/SettingsDrawer.cpp
+++ b/src/activity/reader/Epub/SettingsDrawer.cpp
@@ -419,6 +419,20 @@ void SettingsDrawer::setupMenu() {
       s.markCustomSettings();
     };
     menuItems.push_back(bionicEntry);
+
+    // Global visual overlay (not baked into layout/cache) — same idea as status-bar rows.
+    MenuEntry guideLinesEntry;
+    guideLinesEntry.item = MenuItem::ReadingGuideLines;
+    guideLinesEntry.group = GroupType::LAYOUT;
+    guideLinesEntry.name = "Guide Lines";
+    guideLinesEntry.getValueText = [](const BookSettings&) -> const char* {
+      return READER_SETTINGS.readingGuideLinesEnabled ? "On" : "Off";
+    };
+    guideLinesEntry.change = [](BookSettings&, int) {
+      READER_SETTINGS.readingGuideLinesEnabled = READER_SETTINGS.readingGuideLinesEnabled ? 0 : 1;
+      READER_SETTINGS.saveToFile();
+    };
+    menuItems.push_back(guideLinesEntry);
   }
 
   // The "═══ System ═══" group (Text Anti-Aliasing, Refresh Frequency, Power Button, Long-press,
@@ -697,6 +711,10 @@ void SettingsDrawer::drawMenuItemRow(int visibleRow, int menuIndex) {
         checkbox = true;
         checked = settings.bionicReadingEnabled != 0;
         break;
+      case MenuItem::ReadingGuideLines:
+        checkbox = true;
+        checked = READER_SETTINGS.readingGuideLinesEnabled != 0;
+        break;
       case MenuItem::ReaderSmartImageRefresh:
         checkbox = true;
         checked = settings.readerSmartRefreshOnImages != 0;
@@ -900,6 +918,9 @@ void SettingsDrawer::applyChange(int delta) {
       case MenuItem::ParagraphCssIndent:
       case MenuItem::BionicReading:
       case MenuItem::FontFamily:
+        settingsUpdated = true;
+        break;
+      case MenuItem::ReadingGuideLines:
         settingsUpdated = true;
         break;
       case MenuItem::ReadingOrientation:

--- a/src/activity/reader/Epub/SettingsDrawer.h
+++ b/src/activity/reader/Epub/SettingsDrawer.h
@@ -140,6 +140,7 @@ class SettingsDrawer {
 
     Hyphenation,        ///< Hyphenation toggle
     BionicReading,      ///< Bionic Reading toggle
+    ReadingGuideLines,  ///< Vertical reading-guide lines at page thirds
     AntiAliasing,       ///< Text anti-aliasing toggle
     RefreshRate,        ///< Display refresh frequency
     ReaderPowerButton,  ///< Reader short power button behavior

--- a/src/state/ReaderSetting.cpp
+++ b/src/state/ReaderSetting.cpp
@@ -30,10 +30,10 @@ ReaderSetting ReaderSetting::instance;
 
 namespace {
 constexpr uint8_t READER_SETTINGS_FILE_VERSION = 1;
-// Must equal the number of data fields read by the do-while loop in loadFromFile() (currently 39,
-// through longPressChapterSkip) - NOT counting the version/count header fields read separately
+// Must equal the number of data fields read by the do-while loop in loadFromFile() (currently 40,
+// through readingGuideLinesEnabled) - NOT counting the version/count header fields read separately
 // before the loop. See SystemSetting.cpp's SETTINGS_COUNT comment for how this header is used.
-constexpr uint8_t READER_SETTINGS_COUNT = 39;
+constexpr uint8_t READER_SETTINGS_COUNT = 40;
 constexpr uint8_t LEGACY_IMAGE_PRESENTATION_COUNT = 4;
 constexpr char READER_SETTINGS_FILE[] = "/.system/reader_settings.bin";
 constexpr uint32_t FNV1A_OFFSET = 2166136261UL;
@@ -120,6 +120,7 @@ uint32_t readerSettingsHash(const ReaderSetting& settings, const uint8_t fontFam
   hashPod(hash, settings.refreshFrequency);
   hashPod(hash, settings.hyphenationEnabled);
   hashPod(hash, settings.bionicReadingEnabled);
+  hashPod(hash, settings.readingGuideLinesEnabled);
   hashPod(hash, settings.screenMargin);
   hashPod(hash, settings.pageAutoTurnSeconds);
   hashPod(hash, settings.readerImageGrayscale);
@@ -210,6 +211,7 @@ bool ReaderSetting::saveToFile() const {
   serialization::writePod(outputFile, legacyReaderImagePresentation);
   serialization::writePod(outputFile, readerImageDither);
   serialization::writePod(outputFile, longPressChapterSkip);
+  serialization::writePod(outputFile, readingGuideLinesEnabled);
 
   outputFile.close();
 
@@ -392,6 +394,10 @@ bool ReaderSetting::loadFromFile() {
     if (longPressChapterSkip > SystemSetting::LONG_PRESS_PAGE_SKIP_5) {
       longPressChapterSkip = SystemSetting::LONG_PRESS_CHAPTER_SKIP;
     }
+    if (++settingsRead >= fileSettingsCount) break;
+
+    serialization::readPod(inputFile, readingGuideLinesEnabled);
+    if (readingGuideLinesEnabled > 1) readingGuideLinesEnabled = 0;
     ++settingsRead;
 
   } while (false);

--- a/src/state/ReaderSetting.h
+++ b/src/state/ReaderSetting.h
@@ -96,6 +96,8 @@ class ReaderSetting {
   uint8_t refreshFrequency = 3;  ///< SystemSetting::REFRESH_15 (enum index, not the page count - see getRefreshFrequency())
   uint8_t hyphenationEnabled = 1;    ///< Hyphenation enabled
   uint8_t bionicReadingEnabled = 0;  ///< Bionic Reading enabled
+  /** Vertical reading-guide lines at 1/3 and 2/3 of content width (speed-reading aid). */
+  uint8_t readingGuideLinesEnabled = 0;
 
   uint8_t screenMargin = 10;  ///< Screen margin in pixels
 

--- a/src/state/SystemSetting.cpp
+++ b/src/state/SystemSetting.cpp
@@ -48,14 +48,14 @@ constexpr uint8_t SETTINGS_FILE_VERSION = 37;
 // parsed, so loadFromFile() discards them and starts fresh instead of attempting to read them. See
 // ReaderSetting.cpp for the new reader_settings.bin format (independently versioned from 1).
 constexpr uint8_t MIN_SUPPORTED_SETTINGS_VERSION = 37;
-// Must equal the number of data fields read by the do-while loop in loadFromFile() (currently 38,
-// through shakePageTurnSensitivity - NOT counting the version/count header fields read separately
+// Must equal the number of data fields read by the do-while loop in loadFromFile() (currently 39,
+// through hideButtonHints - NOT counting the version/count header fields read separately
 // before the loop). This is written into the file as its own "how many fields do I contain" header
 // and read back as fileSettingsCount; the loop's `settingsRead < fileSettingsCount` checks use it to
 // know whether the tail fields are actually present. If it's wrong, either the tail fields never get
 // read back even though they were written (undercount), or the file never triggers the self-healing
 // rewrite on old-format files (overcount, since fileSettingsCount can never reach it).
-constexpr uint8_t SETTINGS_COUNT = 38;
+constexpr uint8_t SETTINGS_COUNT = 39;
 constexpr uint8_t LEGACY_IMAGE_PRESENTATION_COUNT = 4;
 constexpr char SETTINGS_FILE[] = "/.system/settings.bin";
 constexpr char UI_THEME_FILE[] = "/.system/ui_theme.bin";
@@ -192,6 +192,7 @@ uint32_t settingsHash(const SystemSetting& settings) {
   hashPod(hash, settings.shakePageTurnSensitivity);
   hashPod(hash, settings.uiTheme);
   hashPod(hash, settings.libraryShelfEnabled);
+  hashPod(hash, settings.hideButtonHints);
   return hash;
 }
 
@@ -287,6 +288,7 @@ bool SystemSetting::saveToFile() const {
   serialization::writePod(outputFile, shakePageTurnSensitivity);
   serialization::writePod(outputFile, uiTheme);
   serialization::writePod(outputFile, libraryShelfEnabled);
+  serialization::writePod(outputFile, hideButtonHints);
 
   outputFile.close();
   saveUiThemeSetting(uiTheme);
@@ -469,6 +471,10 @@ bool SystemSetting::loadFromFile() {
 
     serialization::readPod(inputFile, libraryShelfEnabled);
     if (libraryShelfEnabled > 1) libraryShelfEnabled = 0;
+    if (++settingsRead >= fileSettingsCount) break;
+
+    serialization::readPod(inputFile, hideButtonHints);
+    if (hideButtonHints > 1) hideButtonHints = 0;
     ++settingsRead;
 
   } while (false);
@@ -478,6 +484,7 @@ bool SystemSetting::loadFromFile() {
   if (recentVisibleCount < 1 || recentVisibleCount > 9) recentVisibleCount = 9;
   if (librarySortEnabled > 1) librarySortEnabled = 1;
   if (libraryShelfEnabled > 1) libraryShelfEnabled = 0;
+  if (hideButtonHints > 1) hideButtonHints = 0;
   if (librarySortMode > 7) librarySortMode = 0;
   if (sleepClockStyle >= SLEEP_CLOCK_STYLE_COUNT) sleepClockStyle = CLOCK_CENTERED_DATE;
   if (sleepClockTimeFormat >= CLOCK_TIME_FORMAT_COUNT) sleepClockTimeFormat = CLOCK_24_HOUR;

--- a/src/state/SystemSetting.h
+++ b/src/state/SystemSetting.h
@@ -426,6 +426,8 @@ class SystemSetting {
   uint8_t libraryMode = LIBRARY_GRID;              ///< Library browser display mode
   uint8_t libraryViewMode = LIBRARY_VIEW_FOLDERS;  ///< Last Library browser content view
   uint8_t libraryShelfEnabled = 0;                 ///< Allow cover shelf view in Library
+  /** Hide on-screen button-hint bar on tabbed hub screens (experienced users). */
+  uint8_t hideButtonHints = 0;
   /** How many recent books to show on the Recent hub (1–8). */
   uint8_t recentVisibleCount = 9;
   /** Library: 0 = folders and books A-Z only; 1 = use librarySortMode (favorites / groups / reading / tags). */


### PR DESCRIPTION
## Summary
- **Hide button hints**: new Settings → Device Display toggle (`hideButtonHints`) that skips the on-screen button-hint bar on tabbed hub screens while keeping the tab bar itself.
- **Reading guide lines**: new in-reader Layout setting “Guide Lines” that draws dotted vertical lines at 1/3 and 2/3 of the EPUB content width as a pure visual overlay (not baked into layout/cache).

## Details
- `hideButtonHints` is a persisted `SystemSetting` (settings count 38 → 39).
- `readingGuideLinesEnabled` is a global `ReaderSetting` (count 39 → 40), toggled from the EPUB settings drawer like other global reader chrome.
- Guide lines are drawn after page text and before the BW snapshot so they survive AA/grayscale passes; also redrawn on the high-quality cleanup path.
- Hub screens already go through `Menu::renderButtonHints()` (including Library’s local wrapper), so one gate covers them.

## Test plan
- [ ] Settings → Device Display → enable **Hide button hints**; confirm Recent/Library/Settings/Sync/Statistics no longer show the bottom hint row but still show the tab bar.
- [ ] Open an EPUB → Layout → enable **Guide Lines**; confirm two dotted vertical lines appear at content thirds.
- [ ] Page turn with AA / image quality modes enabled; confirm guide lines remain correct.
- [ ] Disable both settings; confirm previous behavior restored and settings survive reboot.
- [ ] Load older `settings.bin` / `reader_settings.bin` and confirm new fields default off and rewrite cleanly.