### PR TITLE
feat: global hide-hints, faster dictionary, bottom status toasts

### DIFF
--- a/lib/GfxRenderer/UiRender.cpp
+++ b/lib/GfxRenderer/UiRender.cpp
@@ -4,8 +4,17 @@
 
 #include "GfxRenderer.h"
 
+UiRender::HintsHiddenFn UiRender::hintsHiddenFn_ = nullptr;
+
+void UiRender::setHintsHiddenFn(const HintsHiddenFn fn) { hintsHiddenFn_ = fn; }
+
+bool UiRender::hintsHidden() { return hintsHiddenFn_ != nullptr && hintsHiddenFn_(); }
+
 void UiRender::buttonHints(const int fontId, const char* btn1, const char* btn2, const char* btn3,
                            const char* btn4, const int topY) const {
+  if (hintsHidden()) {
+    return;
+  }
   const GfxRenderer::Orientation origOrientation = gfx.getOrientation();
   gfx.setOrientation(GfxRenderer::Orientation::Portrait);
 
@@ -34,6 +43,9 @@ void UiRender::buttonHints(const int fontId, const char* btn1, const char* btn2,
 
 void UiRender::sideButtonHints(const int fontId, const char* powerBtn, const char* topBtn,
                                const char* bottomBtn) const {
+  if (hintsHidden()) {
+    return;
+  }
   if (gfx.deviceIsX3()) {
     constexpr int buttonWidth = 106;
     constexpr int buttonHeight = 40;

--- a/lib/GfxRenderer/UiRender.h
+++ b/lib/GfxRenderer/UiRender.h
@@ -6,6 +6,14 @@ class UiRender {
  public:
   explicit UiRender(GfxRenderer& g) : gfx(g) {}
 
+  /**
+   * Optional app-level policy: when the callback returns true, {@link buttonHints} and
+   * {@link sideButtonHints} become no-ops. Used by firmware to honor "Hide button hints".
+   * Pass nullptr to always draw hints (default).
+   */
+  using HintsHiddenFn = bool (*)();
+  static void setHintsHiddenFn(HintsHiddenFn fn);
+
   /** @param topY Row's top edge; defaults to the standard bottom-anchored position (pageHeight - 40). */
   void buttonHints(int fontId, const char* btn1, const char* btn2, const char* btn3, const char* btn4,
                    int topY = -1) const;
@@ -14,5 +22,8 @@ class UiRender {
   void fillSparseInkLatticeInRect(int x, int y, int width, int height, int latticeStep = 2) const;
 
  private:
+  static bool hintsHidden();
+
   GfxRenderer& gfx;
+  static HintsHiddenFn hintsHiddenFn_;
 };

--- a/src/activity/Menu.h
+++ b/src/activity/Menu.h
@@ -58,9 +58,8 @@ class Menu {
 
   void renderButtonHints(const GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
                          const char* btn4) const {
-    if (!SETTINGS.hideButtonHints) {
-      INX_THEME.drawButtonHints(renderer, ATKINSON_HYPERLEGIBLE_10_FONT_ID, btn1, btn2, btn3, btn4);
-    }
+    // Button-hint suppression is global (UiRender policy from SETTINGS.hideButtonHints).
+    INX_THEME.drawButtonHints(renderer, ATKINSON_HYPERLEGIBLE_10_FONT_ID, btn1, btn2, btn3, btn4);
     if (INX_THEME.mainTabsAtBottom()) {
       renderTabBar(renderer);
     }

--- a/src/activity/page/SettingsActivity.cpp
+++ b/src/activity/page/SettingsActivity.cpp
@@ -47,8 +47,8 @@ std::vector<SettingInfo> buildSystemPageSettings(const bool x3) {
   settings.push_back(
       SettingInfo::Enum("Library Mode", &SystemSetting::libraryMode, {"List", "Grid"}, GroupType::DEVICE_DISPLAY));
   settings.push_back(SettingInfo::Toggle("Shelf mode", &SystemSetting::libraryShelfEnabled, GroupType::DEVICE_DISPLAY));
-  settings.push_back(
-      SettingInfo::Toggle("Hide button hints", &SystemSetting::hideButtonHints, GroupType::DEVICE_DISPLAY));
+  settings.push_back(SettingInfo::Toggle("Hide button hints", &SystemSetting::hideButtonHints,
+                                         GroupType::DEVICE_DISPLAY));  // All screens / reader overlays
   settings.push_back(SettingInfo::Value("Recent books shown", &SystemSetting::recentVisibleCount, {1, 9, 1},
                                         GroupType::DEVICE_DISPLAY));
 

--- a/src/activity/reader/Epub/EpubActivity.cpp
+++ b/src/activity/reader/Epub/EpubActivity.cpp
@@ -1957,7 +1957,7 @@ void EpubActivity::drawReadingGuideLines(const Page& page, const int orientedMar
     return;
   }
   const int contentWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;
-  if (contentWidth < 3) {
+  if (contentWidth < 4) {
     return;
   }
   const int lineTop = orientedMarginTop;
@@ -1996,8 +1996,10 @@ void EpubActivity::drawReadingGuideLines(const Page& page, const int orientedMar
     }
     return;
   }
-  const int x1 = orientedMarginLeft + contentWidth / 3;
-  const int x2 = orientedMarginLeft + (contentWidth * 2) / 3;
+  // Grid mode: 25% / 75% of content width so ~half the page sits between the guides
+  // (1/3–2/3 is too narrow on small XTE screens).
+  const int x1 = orientedMarginLeft + contentWidth / 4;
+  const int x2 = orientedMarginLeft + (contentWidth * 3) / 4;
   // Dotted so the guides cue fixation without fighting body text on e-ink.
   renderer.line.render(x1, lineTop, x1, lineBottom, true, LineRender::Style::Dotted);
   renderer.line.render(x2, lineTop, x2, lineBottom, true, LineRender::Style::Dotted);

--- a/src/activity/reader/Epub/EpubActivity.h
+++ b/src/activity/reader/Epub/EpubActivity.h
@@ -184,7 +184,7 @@ class EpubActivity final : public ActivityWithSubactivity {
   void renderStatusBar(int orientedMarginRight, int orientedMarginBottom, int orientedMarginLeft) const;
 
   /**
-   * Draws the reading-guide overlay when enabled: Grid (vertical lines at 1/3 and 2/3 of the content width)
+   * Draws the reading-guide overlay when enabled: Grid (vertical lines at 25% and 75% of the content width)
    * or Notebook (one horizontal ruled line under each actual text line on the page, so blank space - end of
    * page, gaps around images - never gets a stray line and every line lands exactly under real text).
    * Pure overlay — does not affect layout or page cache.

--- a/src/activity/reader/Epub/EpubDictionaryUi.cpp
+++ b/src/activity/reader/Epub/EpubDictionaryUi.cpp
@@ -188,12 +188,9 @@ void EpubDictionaryUi::exit(EpubActivity& act) {
   releaseDefinitionMemory();
   std::vector<PageWordHit>().swap(words_);
   std::vector<size_t>().swap(lineFirst_);
-  // dict_ holds the on-SD dictionary's in-RAM checkpoint index once opened (hundreds of entries for
-  // a large dictionary, tens of KB) - close it here instead of leaving it open for the rest of the
-  // reading session just because the user looked something up once. ensureDictionaryOpen() re-attempts
-  // opening (and re-scans the index) next time the user actually looks something up.
-  dict_.close();
-  dictOpenAttempted_ = false;
+  // Keep dict_ open for the rest of the book session: reopening rebuilds the checkpoint index with a
+  // full .idx scan, which is the cold-path cost we just paid on the first lookup. RAM held is tens of
+  // KB of checkpoints; reclaimed when the reader activity is destroyed (dict_ is a member).
   lastNavEdgeDir_ = -1;
   navRepeatDir_ = -1;
   for (auto& ch : captureChunks_) {
@@ -218,15 +215,15 @@ void EpubDictionaryUi::releaseDefinitionMemory() {
 }
 
 void EpubDictionaryUi::ensureDictionaryOpen() {
-  if (dictOpenAttempted_) {
-    return;
-  }
-  dictOpenAttempted_ = true;
   if (READER_SETTINGS.dictionaryFolder[0] == '\0') {
     Serial.printf("[%lu] [DICT] ensureDictionaryOpen: READER_SETTINGS.dictionaryFolder is empty\n", millis());
     return;
   }
   const std::string folder = std::string("/dictionaries/") + READER_SETTINGS.dictionaryFolder;
+  // open() is a no-op when the same folder is already warm - safe to call every lookup.
+  if (dict_.isOpen() && dict_.folderPath() == folder) {
+    return;
+  }
   const bool opened = dict_.open(folder);
   Serial.printf("[%lu] [DICT] ensureDictionaryOpen: open('%s') -> %d\n", millis(), folder.c_str(), opened ? 1 : 0);
 }
@@ -246,11 +243,14 @@ void EpubDictionaryUi::performLookup(EpubActivity& act) {
   } else if (READER_SETTINGS.dictionaryFolder[0] == '\0') {
     currentDefinition_ = "No dictionary selected. Pick one in Settings > Reader > Choose dictionary.";
   } else {
-    // Show the status popup FIRST, before any blocking work - opening the dictionary (first lookup
-    // only) and the SD scan itself can together take several seconds on a large dictionary, and both
-    // must happen after the popup is on screen for it to actually look instant. readerPopup() forces
-    // an immediate flush, same pattern as its other callers (e.g. "Deleting book...").
-    act.readerPopup("Looking up...");
+    const std::string folder = std::string("/dictionaries/") + READER_SETTINGS.dictionaryFolder;
+    const bool alreadyWarm = dict_.isOpen() && dict_.folderPath() == folder;
+    // Cold open (first lookup this session) can still take a second or two while checkpoints are
+    // built - show a toast so the device doesn't look frozen. Warm lookups aim to be near-instant,
+    // so skip the popup and avoid an extra full-screen e-ink refresh.
+    if (!alreadyWarm) {
+      act.readerPopup("Opening dictionary...");
+    }
     ensureDictionaryOpen();
     if (!dict_.isOpen()) {
       currentDefinition_ = "Could not open the selected dictionary.";

--- a/src/activity/reader/Epub/EpubDictionaryUi.h
+++ b/src/activity/reader/Epub/EpubDictionaryUi.h
@@ -55,7 +55,6 @@ class EpubDictionaryUi {
   size_t focus_ = 0;
 
   StarDictLookup dict_;
-  bool dictOpenAttempted_ = false;
   bool showingDefinition_ = false;
   std::string lookedUpWord_;
   bool wordAlreadySaved_ = false;

--- a/src/activity/reader/Epub/SettingsDrawer.cpp
+++ b/src/activity/reader/Epub/SettingsDrawer.cpp
@@ -421,6 +421,7 @@ void SettingsDrawer::setupMenu() {
     menuItems.push_back(bionicEntry);
 
     // Per-book (pure visual overlay, never baked into layout/cache) — same pattern as hyphenation/bionic above.
+    // Grid lines sit at 25%/75% of content width so ~half the page is the fixation band.
     MenuEntry guideLinesEntry;
     guideLinesEntry.item = MenuItem::ReadingGuideLines;
     guideLinesEntry.group = GroupType::LAYOUT;

--- a/src/activity/reader/Epub/SettingsDrawer.h
+++ b/src/activity/reader/Epub/SettingsDrawer.h
@@ -140,7 +140,7 @@ class SettingsDrawer {
 
     Hyphenation,        ///< Hyphenation toggle
     BionicReading,      ///< Bionic Reading toggle
-    ReadingGuideLines,  ///< Reading-guide overlay style: Off / Grid (vertical thirds) / Notebook (ruled lines)
+    ReadingGuideLines,  ///< Reading-guide overlay style: Off / Grid (vertical 25%/75%) / Notebook (ruled lines)
     AntiAliasing,       ///< Text anti-aliasing toggle
     RefreshRate,        ///< Display refresh frequency
     ReaderPowerButton,  ///< Reader short power button behavior

--- a/src/dictionary/StarDictLookup.cpp
+++ b/src/dictionary/StarDictLookup.cpp
@@ -5,50 +5,11 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 
 #include "util/StringUtils.h"
 
 namespace {
-
-uint32_t readBigEndian32(FsFile& f) {
-  uint8_t b[4] = {0, 0, 0, 0};
-  if (f.read(b, 4) != 4) {
-    return 0;
-  }
-  return (static_cast<uint32_t>(b[0]) << 24) | (static_cast<uint32_t>(b[1]) << 16) |
-         (static_cast<uint32_t>(b[2]) << 8) | static_cast<uint32_t>(b[3]);
-}
-
-uint64_t readBigEndian64(FsFile& f) {
-  uint8_t b[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-  if (f.read(b, 8) != 8) {
-    return 0;
-  }
-  uint64_t v = 0;
-  for (int i = 0; i < 8; ++i) {
-    v = (v << 8) | static_cast<uint64_t>(b[i]);
-  }
-  return v;
-}
-
-/** Reads a null-terminated word from f into out. Returns false on EOF before a terminator or if
- *  the word looks corrupt (unreasonably long, which would otherwise scan indefinitely). */
-bool readCString(FsFile& f, std::string& out) {
-  out.clear();
-  char c = 0;
-  while (true) {
-    if (f.read(&c, 1) != 1) {
-      return false;
-    }
-    if (c == '\0') {
-      return true;
-    }
-    out += c;
-    if (out.size() > 256) {
-      return false;
-    }
-  }
-}
 
 std::string toLowerCopy(const std::string& s) {
   std::string out = s;
@@ -94,12 +55,10 @@ std::vector<std::string> stemCandidates(const std::string& lower) {
     }
   };
 
-  // Possessive: "dog's" -> "dog" (stripPunctuation keeps apostrophes, so this can reach here).
   if (n > 2 && lower[n - 2] == '\'' && lower[n - 1] == 's') {
     add(lower.substr(0, n - 2));
   }
 
-  // -ing: running->runn->run (doubled consonant), making->make (silent e), jumping->jump.
   if (n > 4 && lower.compare(n - 3, 3, "ing") == 0) {
     const std::string base = lower.substr(0, n - 3);
     add(base);
@@ -109,12 +68,10 @@ std::vector<std::string> stemCandidates(const std::string& lower) {
     }
   }
 
-  // -ied: tried->tri->try.
   if (n > 3 && lower.compare(n - 3, 3, "ied") == 0) {
     add(lower.substr(0, n - 3) + "y");
   }
 
-  // -ed: jumped->jump, liked/lik->like, stopped/stopp->stop.
   if (n > 3 && lower.compare(n - 2, 2, "ed") == 0) {
     const std::string base = lower.substr(0, n - 2);
     add(base);
@@ -124,17 +81,14 @@ std::vector<std::string> stemCandidates(const std::string& lower) {
     }
   }
 
-  // -ies: flies->fly, berries->berry.
   if (n > 4 && lower.compare(n - 3, 3, "ies") == 0) {
     add(lower.substr(0, n - 3) + "y");
   }
 
-  // -es: boxes->box, watches->watch.
   if (n > 3 && lower.compare(n - 2, 2, "es") == 0) {
     add(lower.substr(0, n - 2));
   }
 
-  // -s: books->book (skip "ss" endings like "glass" and words already handled above).
   if (n > 2 && lower[n - 1] == 's' && lower[n - 2] != 's') {
     add(lower.substr(0, n - 1));
   }
@@ -142,13 +96,131 @@ std::vector<std::string> stemCandidates(const std::string& lower) {
   return out;
 }
 
+void pushUnique(std::vector<std::string>& list, const std::string& s) {
+  if (s.empty()) {
+    return;
+  }
+  if (std::find(list.begin(), list.end(), s) == list.end()) {
+    list.push_back(s);
+  }
+}
+
 }  // namespace
 
-int StarDictLookup::compareWord(const std::string& a, const std::string& b) {
-  // Plain byte-order comparison, matching StarDict's conventional strcmp-based .idx sort - this is
-  // the true on-disk order the checkpoint binary search relies on.
-  return a.compare(b);
+// ---------------------------------------------------------------------------
+// IdxCursor - buffered sequential .idx access
+// ---------------------------------------------------------------------------
+
+StarDictLookup::IdxCursor::IdxCursor(FsFile& file, const uint32_t fileSize) : file_(file), fileSize_(fileSize) {}
+
+bool StarDictLookup::IdxCursor::fillFrom(const uint32_t absOffset) {
+  if (absOffset >= fileSize_) {
+    bufBase_ = absOffset;
+    bufLen_ = 0;
+    return false;
+  }
+  if (!file_.seekSet(absOffset)) {
+    bufBase_ = absOffset;
+    bufLen_ = 0;
+    return false;
+  }
+  const uint32_t toRead = std::min(kBufSize, fileSize_ - absOffset);
+  const int n = file_.read(buf_, toRead);
+  if (n <= 0) {
+    bufBase_ = absOffset;
+    bufLen_ = 0;
+    return false;
+  }
+  bufBase_ = absOffset;
+  bufLen_ = static_cast<uint32_t>(n);
+  return true;
 }
+
+bool StarDictLookup::IdxCursor::ensure(const uint32_t needBytes) {
+  if (pos_ >= fileSize_) {
+    return false;
+  }
+  if (pos_ >= bufBase_ && (pos_ + needBytes) <= (bufBase_ + bufLen_)) {
+    return true;
+  }
+  // Prefer filling a fresh window starting at pos_. If the remaining file is shorter than needBytes
+  // we still succeed as long as at least one byte is available (callers check partial failures).
+  return fillFrom(pos_) && bufLen_ > 0;
+}
+
+bool StarDictLookup::IdxCursor::seek(const uint32_t absOffset) {
+  pos_ = absOffset;
+  if (pos_ >= bufBase_ && pos_ < (bufBase_ + bufLen_)) {
+    return pos_ <= fileSize_;
+  }
+  // Lazy: don't hit the SD until the next read. Mark buffer empty so ensure() refills.
+  if (pos_ < bufBase_ || pos_ >= (bufBase_ + bufLen_)) {
+    bufLen_ = 0;
+  }
+  return pos_ <= fileSize_;
+}
+
+bool StarDictLookup::IdxCursor::readRaw(uint8_t* dest, const uint32_t n) {
+  uint32_t remaining = n;
+  uint32_t wrote = 0;
+  while (remaining > 0) {
+    if (!ensure(1)) {
+      return false;
+    }
+    const uint32_t bufOff = pos_ - bufBase_;
+    const uint32_t avail = bufLen_ - bufOff;
+    const uint32_t take = std::min(remaining, avail);
+    std::memcpy(dest + wrote, buf_ + bufOff, take);
+    pos_ += take;
+    wrote += take;
+    remaining -= take;
+  }
+  return true;
+}
+
+bool StarDictLookup::IdxCursor::readCString(std::string& out) {
+  out.clear();
+  while (true) {
+    if (!ensure(1)) {
+      return false;
+    }
+    const uint8_t c = buf_[pos_ - bufBase_];
+    ++pos_;
+    if (c == 0) {
+      return true;
+    }
+    out.push_back(static_cast<char>(c));
+    if (out.size() > 256) {
+      return false;
+    }
+  }
+}
+
+bool StarDictLookup::IdxCursor::readBE32(uint32_t& out) {
+  uint8_t b[4];
+  if (!readRaw(b, 4)) {
+    return false;
+  }
+  out = (static_cast<uint32_t>(b[0]) << 24) | (static_cast<uint32_t>(b[1]) << 16) |
+        (static_cast<uint32_t>(b[2]) << 8) | static_cast<uint32_t>(b[3]);
+  return true;
+}
+
+bool StarDictLookup::IdxCursor::readBE64(uint64_t& out) {
+  uint8_t b[8];
+  if (!readRaw(b, 8)) {
+    return false;
+  }
+  out = 0;
+  for (int i = 0; i < 8; ++i) {
+    out = (out << 8) | static_cast<uint64_t>(b[i]);
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// StarDictLookup
+// ---------------------------------------------------------------------------
 
 void StarDictLookup::close() {
   if (idxFile_) {
@@ -160,11 +232,14 @@ void StarDictLookup::close() {
   // swap, not .clear() - checkpoints_ is the in-RAM index built by buildCheckpoints() (hundreds of
   // entries for a large dictionary), and .clear() alone would leave that capacity reserved.
   std::vector<Checkpoint>().swap(checkpoints_);
+  std::vector<DefCacheEntry>().swap(defCache_);
+  std::string().swap(folderPath_);
   std::string().swap(bookname_);
   std::string().swap(sameTypeSequence_);
   wordCount_ = 0;
   idxFileSize_ = 0;
   use64BitOffsets_ = false;
+  caseInsensitiveSort_ = false;
   isOpen_ = false;
 }
 
@@ -210,6 +285,10 @@ bool StarDictLookup::parseIfo(const std::string& ifoPath) {
 }
 
 bool StarDictLookup::open(const std::string& folderPath) {
+  // Already open on the same folder - keep warm index/files (common when dictionary mode is re-entered).
+  if (isOpen_ && folderPath_ == folderPath) {
+    return true;
+  }
   close();
 
   std::string ifoPath, idxPath, dictPath;
@@ -254,9 +333,7 @@ bool StarDictLookup::open(const std::string& folderPath) {
   }
 
   // Some third-party-generated .ifo files carry a stale/wrong idxfilesize (e.g. after the .idx was
-  // regenerated by a converter that didn't update the header). Always trust the actual on-disk size -
-  // buildCheckpoints()/lookupViaLinearScan() bound their scans by this value, so a wrong number here
-  // would silently truncate or overrun the index.
+  // regenerated by a converter that didn't update the header). Always trust the actual on-disk size.
   const uint32_t actualIdxSize = static_cast<uint32_t>(idxFile_.fileSize());
   if (idxFileSize_ != actualIdxSize) {
     Serial.printf("[%lu] [DICT] .ifo idxfilesize=%u does not match actual .idx size=%u - using actual\n", millis(),
@@ -266,79 +343,140 @@ bool StarDictLookup::open(const std::string& folderPath) {
   Serial.printf("[%lu] [DICT] .idx actual size=%u .dict actual size=%llu\n", millis(), idxFileSize_,
                 static_cast<unsigned long long>(dictFile_.fileSize()));
 
+  const unsigned long t0 = millis();
   if (!buildCheckpoints()) {
     Serial.printf("[%lu] [DICT] Could not build index checkpoints for %s\n", millis(), folderPath.c_str());
     close();
     return false;
   }
 
+  folderPath_ = folderPath;
   isOpen_ = true;
-  Serial.printf("[%lu] [DICT] Opened '%s' (%u words, %u checkpoints, %s offsets)\n", millis(), bookname_.c_str(),
-                wordCount_, static_cast<unsigned>(checkpoints_.size()), use64BitOffsets_ ? "64-bit" : "32-bit");
+  Serial.printf("[%lu] [DICT] Opened '%s' (%u words, %u checkpoints, %s offsets, sort=%s) in %lums\n", millis(),
+                bookname_.c_str(), wordCount_, static_cast<unsigned>(checkpoints_.size()),
+                use64BitOffsets_ ? "64-bit" : "32-bit", caseInsensitiveSort_ ? "case-insensitive" : "byte-order",
+                millis() - t0);
   return true;
 }
 
-bool StarDictLookup::readIdxEntryAt(const uint32_t idxOffset, std::string& outEntryText, uint64_t& outDictOffset,
-                                    uint32_t& outDictSize, uint32_t& outNextOffset) {
-  if (!idxFile_.seekSet(idxOffset)) {
+bool StarDictLookup::readIdxEntry(IdxCursor& cur, std::string& outEntryText, uint64_t& outDictOffset,
+                                  uint32_t& outDictSize) {
+  if (!cur.readCString(outEntryText)) {
     return false;
   }
-  if (!readCString(idxFile_, outEntryText)) {
-    return false;
+  if (use64BitOffsets_) {
+    if (!cur.readBE64(outDictOffset)) {
+      return false;
+    }
+  } else {
+    uint32_t off32 = 0;
+    if (!cur.readBE32(off32)) {
+      return false;
+    }
+    outDictOffset = off32;
   }
-  outDictOffset = use64BitOffsets_ ? readBigEndian64(idxFile_) : static_cast<uint64_t>(readBigEndian32(idxFile_));
-  outDictSize = readBigEndian32(idxFile_);
-  outNextOffset = static_cast<uint32_t>(idxFile_.position());
-  return true;
+  return cur.readBE32(outDictSize);
 }
 
 bool StarDictLookup::buildCheckpoints() {
   checkpoints_.clear();
-  uint32_t offset = 0;
+  if (wordCount_ > 0) {
+    // Reserve roughly wordCount/stride slots so we don't reallocate during the scan.
+    const size_t estimate = static_cast<size_t>(wordCount_ / kCheckpointStride) + 2;
+    checkpoints_.reserve(std::min(estimate, static_cast<size_t>(8192)));
+  }
+
+  IdxCursor cur(idxFile_, idxFileSize_);
+  if (!cur.seek(0)) {
+    return false;
+  }
+
   uint32_t count = 0;
-  while (offset < idxFileSize_) {
+  std::string prevText;
+  std::string prevLower;
+  bool havePrev = false;
+  uint32_t byteOrderViolations = 0;
+  uint32_t caseFoldViolations = 0;
+
+  while (cur.position() < idxFileSize_) {
+    const uint32_t entryOffset = cur.position();
     std::string entryText;
     uint64_t dictOffset = 0;
-    uint32_t dictSize = 0, nextOffset = 0;
-    if (!readIdxEntryAt(offset, entryText, dictOffset, dictSize, nextOffset)) {
+    uint32_t dictSize = 0;
+    if (!readIdxEntry(cur, entryText, dictOffset, dictSize)) {
       Serial.printf("[%lu] [DICT] buildCheckpoints: read failed at offset=%u after %u entries (idxFileSize=%u)\n",
-                    millis(), offset, count, idxFileSize_);
+                    millis(), entryOffset, count, idxFileSize_);
       break;
     }
+    if (cur.position() <= entryOffset) {
+      Serial.printf("[%lu] [DICT] buildCheckpoints: non-advancing entry at offset=%u ('%s') - stopping\n", millis(),
+                    entryOffset, entryText.c_str());
+      break;
+    }
+
+    const std::string entryLower = toLowerCopy(entryText);
+    if (havePrev) {
+      if (prevText.compare(entryText) > 0) {
+        ++byteOrderViolations;
+      }
+      if (prevLower.compare(entryLower) > 0) {
+        ++caseFoldViolations;
+      }
+    }
+    prevText = entryText;
+    prevLower = entryLower;
+    havePrev = true;
+
     if (count % kCheckpointStride == 0) {
-      checkpoints_.push_back(Checkpoint{offset, entryText});
+      checkpoints_.emplace_back(entryOffset, entryText, entryLower);
       if (checkpoints_.size() <= 3) {
         Serial.printf("[%lu] [DICT] checkpoint #%u @offset=%u entry='%s'\n", millis(),
-                      static_cast<unsigned>(checkpoints_.size() - 1), offset, entryText.c_str());
+                      static_cast<unsigned>(checkpoints_.size() - 1), entryOffset, entryText.c_str());
       }
     }
     ++count;
-    if (nextOffset <= offset) {
-      // Malformed/looping entry - stop rather than spin forever.
-      Serial.printf("[%lu] [DICT] buildCheckpoints: non-advancing entry at offset=%u ('%s') - stopping\n", millis(),
-                    offset, entryText.c_str());
-      break;
-    }
-    offset = nextOffset;
   }
-  Serial.printf("[%lu] [DICT] buildCheckpoints: scanned %u entries total (.ifo wordcount=%u), %u checkpoints, "
-                "last checkpoint entry='%s'\n",
-                millis(), count, wordCount_, static_cast<unsigned>(checkpoints_.size()),
+
+  // Prefer case-insensitive binary search when the file is (mostly) sorted that way and NOT sorted
+  // by plain byte order - the classic third-party failure mode that used to force a full linear scan.
+  // Allow a few local violations (duplicate/near-dup noise) before rejecting a sort order.
+  const uint32_t violationBudget = std::max<uint32_t>(4, count / 5000);
+  const bool byteOk = byteOrderViolations <= violationBudget;
+  const bool caseOk = caseFoldViolations <= violationBudget;
+  if (caseOk && !byteOk) {
+    caseInsensitiveSort_ = true;
+  } else {
+    caseInsensitiveSort_ = false;
+  }
+
+  Serial.printf("[%lu] [DICT] buildCheckpoints: scanned %u entries (.ifo wordcount=%u), %u checkpoints, "
+                "byteOrderViolations=%u caseFoldViolations=%u sort=%s, last='%s'\n",
+                millis(), count, wordCount_, static_cast<unsigned>(checkpoints_.size()), byteOrderViolations,
+                caseFoldViolations, caseInsensitiveSort_ ? "case-insensitive" : "byte-order",
                 checkpoints_.empty() ? "" : checkpoints_.back().entryText.c_str());
   return !checkpoints_.empty();
 }
 
-bool StarDictLookup::lookupViaCheckpoints(const std::string& candidate, uint64_t& outDictOffset,
-                                          uint32_t& outDictSize) {
+int StarDictLookup::compareForSearch(const std::string& a, const std::string& aLower, const std::string& b,
+                                     const std::string& bLower) const {
+  if (caseInsensitiveSort_) {
+    return aLower.compare(bLower);
+  }
+  return a.compare(b);
+}
+
+bool StarDictLookup::lookupViaCheckpoints(const std::string& candidate, const std::string& candidateLower,
+                                          uint64_t& outDictOffset, uint32_t& outDictSize) {
   if (checkpoints_.empty()) {
     return false;
   }
-  // Binary search checkpoints_ for the last checkpoint whose word is <= candidate. Only correct if
-  // .idx is actually sorted in plain byte order, per the documented StarDict convention.
+
+  // Binary search for the last checkpoint whose word is <= candidate under the detected sort order.
   size_t lo = 0, hi = checkpoints_.size();
   while (lo < hi) {
     const size_t mid = lo + (hi - lo) / 2;
-    if (compareWord(checkpoints_[mid].entryText, candidate) <= 0) {
+    const Checkpoint& cp = checkpoints_[mid];
+    if (compareForSearch(cp.entryText, cp.entryLower, candidate, candidateLower) <= 0) {
       lo = mid + 1;
     } else {
       hi = mid;
@@ -347,55 +485,143 @@ bool StarDictLookup::lookupViaCheckpoints(const std::string& candidate, uint64_t
   if (lo == 0) {
     return false;
   }
+
   const uint32_t scanStart = checkpoints_[lo - 1].idxOffset;
   const uint32_t scanEnd = (lo < checkpoints_.size()) ? checkpoints_[lo].idxOffset : idxFileSize_;
 
-  uint32_t offset = scanStart;
-  while (offset < scanEnd) {
+  IdxCursor cur(idxFile_, idxFileSize_);
+  if (!cur.seek(scanStart)) {
+    return false;
+  }
+
+  while (cur.position() < scanEnd) {
     std::string entryWord;
     uint64_t dictOffset = 0;
-    uint32_t dictSize = 0, nextOffset = 0;
-    if (!readIdxEntryAt(offset, entryWord, dictOffset, dictSize, nextOffset)) {
+    uint32_t dictSize = 0;
+    if (!readIdxEntry(cur, entryWord, dictOffset, dictSize)) {
       break;
     }
-    const int cmp = compareWord(entryWord, candidate);
+    const std::string entryLower = toLowerCopy(entryWord);
+    const int cmp = compareForSearch(entryWord, entryLower, candidate, candidateLower);
     if (cmp == 0) {
       outDictOffset = dictOffset;
       outDictSize = dictSize;
       return true;
     }
     if (cmp > 0) {
-      break;  // passed where candidate would sort - not present in this checkpoint bracket.
-    }
-    if (nextOffset <= offset) {
+      // Passed where the candidate would sort - not present in this bracket under the assumed order.
+      // For case-insensitive sort, also accept a case-only mismatch that strcmp would reject but
+      // lower-compare already handled via compareForSearch == 0 above.
       break;
     }
-    offset = nextOffset;
   }
   return false;
 }
 
-bool StarDictLookup::lookupViaLinearScan(const std::string& candidateLower, uint64_t& outDictOffset,
-                                         uint32_t& outDictSize) {
-  uint32_t offset = 0;
-  while (offset < idxFileSize_) {
+bool StarDictLookup::lookupViaLinearScan(const std::vector<std::string>& candidatesLower, std::string& outHitLower,
+                                         uint64_t& outDictOffset, uint32_t& outDictSize) {
+  if (candidatesLower.empty()) {
+    return false;
+  }
+
+  // Track best (lowest index in candidatesLower) hit so we prefer the as-typed base form over a stem.
+  int bestPriority = -1;
+  uint64_t bestOffset = 0;
+  uint32_t bestSize = 0;
+  std::string bestLower;
+
+  IdxCursor cur(idxFile_, idxFileSize_);
+  if (!cur.seek(0)) {
+    return false;
+  }
+
+  while (cur.position() < idxFileSize_) {
     std::string entryWord;
     uint64_t dictOffset = 0;
-    uint32_t dictSize = 0, nextOffset = 0;
-    if (!readIdxEntryAt(offset, entryWord, dictOffset, dictSize, nextOffset)) {
+    uint32_t dictSize = 0;
+    if (!readIdxEntry(cur, entryWord, dictOffset, dictSize)) {
       break;
     }
-    if (toLowerCopy(entryWord) == candidateLower) {
-      outDictOffset = dictOffset;
-      outDictSize = dictSize;
+    const std::string entryLower = toLowerCopy(entryWord);
+    for (size_t i = 0; i < candidatesLower.size(); ++i) {
+      if (entryLower == candidatesLower[i]) {
+        if (bestPriority < 0 || static_cast<int>(i) < bestPriority) {
+          bestPriority = static_cast<int>(i);
+          bestOffset = dictOffset;
+          bestSize = dictSize;
+          bestLower = entryLower;
+          // Exact first candidate - can't do better.
+          if (bestPriority == 0) {
+            outHitLower = bestLower;
+            outDictOffset = bestOffset;
+            outDictSize = bestSize;
+            return true;
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  if (bestPriority < 0) {
+    return false;
+  }
+  outHitLower = bestLower;
+  outDictOffset = bestOffset;
+  outDictSize = bestSize;
+  return true;
+}
+
+bool StarDictLookup::readDefinition(const uint64_t dictOffset, const uint32_t dictSize, std::string& outDefinition,
+                                    bool* outTruncated) {
+  if (dictSize == 0 || !dictFile_.seekSet(dictOffset)) {
+    return false;
+  }
+  const uint32_t readSize = std::min(dictSize, kMaxDefinitionBytes);
+  if (outTruncated) {
+    *outTruncated = readSize < dictSize;
+  }
+  outDefinition.resize(readSize);
+  const int readN = dictFile_.read(&outDefinition[0], readSize);
+  return readN == static_cast<int>(readSize);
+}
+
+bool StarDictLookup::cacheGet(const std::string& keyLower, std::string& outDefinition, bool* outTruncated) {
+  for (size_t i = 0; i < defCache_.size(); ++i) {
+    if (defCache_[i].keyLower == keyLower) {
+      outDefinition = defCache_[i].definition;
+      if (outTruncated) {
+        *outTruncated = defCache_[i].truncated;
+      }
+      // Move to front (MRU).
+      if (i > 0) {
+        DefCacheEntry hit = std::move(defCache_[i]);
+        defCache_.erase(defCache_.begin() + static_cast<std::ptrdiff_t>(i));
+        defCache_.insert(defCache_.begin(), std::move(hit));
+      }
       return true;
     }
-    if (nextOffset <= offset) {
-      break;
-    }
-    offset = nextOffset;
   }
   return false;
+}
+
+void StarDictLookup::cachePut(const std::string& keyLower, const std::string& definition, const bool truncated) {
+  for (size_t i = 0; i < defCache_.size(); ++i) {
+    if (defCache_[i].keyLower == keyLower) {
+      defCache_[i].definition = definition;
+      defCache_[i].truncated = truncated;
+      if (i > 0) {
+        DefCacheEntry hit = std::move(defCache_[i]);
+        defCache_.erase(defCache_.begin() + static_cast<std::ptrdiff_t>(i));
+        defCache_.insert(defCache_.begin(), std::move(hit));
+      }
+      return;
+    }
+  }
+  if (defCache_.size() >= kDefCacheSlots) {
+    defCache_.pop_back();
+  }
+  defCache_.insert(defCache_.begin(), DefCacheEntry{keyLower, definition, truncated});
 }
 
 bool StarDictLookup::lookup(const std::string& queryWord, std::string& outDefinition, bool* outTruncated) {
@@ -410,25 +636,35 @@ bool StarDictLookup::lookup(const std::string& queryWord, std::string& outDefini
     return false;
   }
 
-  uint64_t dictOffset = 0;
-  uint32_t dictSize = 0;
-  bool found = false;
-
   const std::string lowerCleaned = toLowerCopy(cleaned);
 
-  // Word forms to try, in priority order: the word as typed/cased, then (if the word carries an
-  // inflectional suffix like -s/-ed/-ing/'s) heuristic base forms, so "running"/"books"/"jumped"
-  // can still resolve to "run"/"book"/"jump" when the inflected form isn't its own dictionary entry.
-  std::vector<std::string> candidates = {cleaned, lowerCleaned, toTitleCaseCopy(cleaned)};
+  // Cache is keyed by the cleaned lowercased query (not the stem that eventually hit) so the same
+  // on-screen word always resolves instantly on re-lookup.
+  if (cacheGet(lowerCleaned, outDefinition, outTruncated)) {
+    Serial.printf("[%lu] [DICT] lookup('%s'): cache hit\n", millis(), queryWord.c_str());
+    return true;
+  }
+
+  // Word forms to try, in priority order: as typed, lower, Title; then stems (lower + Title).
+  std::vector<std::string> candidates;
+  candidates.reserve(12);
+  pushUnique(candidates, cleaned);
+  pushUnique(candidates, lowerCleaned);
+  pushUnique(candidates, toTitleCaseCopy(cleaned));
   for (const std::string& stem : stemCandidates(lowerCleaned)) {
-    candidates.push_back(stem);
-    candidates.push_back(toTitleCaseCopy(stem));
+    pushUnique(candidates, stem);
+    pushUnique(candidates, toTitleCaseCopy(stem));
   }
 
   const unsigned long t0 = millis();
+  uint64_t dictOffset = 0;
+  uint32_t dictSize = 0;
+  bool found = false;
   std::string hitCandidate;
+
   for (const std::string& candidate : candidates) {
-    if (lookupViaCheckpoints(candidate, dictOffset, dictSize)) {
+    const std::string candidateLower = toLowerCopy(candidate);
+    if (lookupViaCheckpoints(candidate, candidateLower, dictOffset, dictSize)) {
       found = true;
       hitCandidate = candidate;
       Serial.printf("[%lu] [DICT] lookup('%s'): fast path hit on candidate='%s' (%lums)\n", millis(),
@@ -438,26 +674,18 @@ bool StarDictLookup::lookup(const std::string& queryWord, std::string& outDefini
   }
 
   if (!found) {
-    Serial.printf("[%lu] [DICT] lookup('%s'): fast path missed (%lums), falling back to linear scan over %u "
-                  "idx bytes\n",
+    Serial.printf("[%lu] [DICT] lookup('%s'): fast path missed (%lums), buffered linear scan over %u idx bytes\n",
                   millis(), queryWord.c_str(), millis() - t0, idxFileSize_);
     const unsigned long t1 = millis();
-    // The fast path assumes .idx is sorted in plain byte order (the documented StarDict
-    // convention). Many third-party-generated dictionaries sort case-insensitively instead, which
-    // silently breaks the checkpoint binary search above for every lookup. Fall back to a full
-    // sequential scan, which is correct regardless of the actual on-disk order. Try the same
-    // as-typed-then-stemmed candidate list here too, so the stemming fallback isn't lost for
-    // dictionaries that only work via linear scan.
-    std::vector<std::string> linearCandidates = {lowerCleaned};
-    for (const std::string& stem : stemCandidates(lowerCleaned)) {
-      linearCandidates.push_back(stem);
+    std::vector<std::string> linearCandidates;
+    linearCandidates.reserve(candidates.size());
+    for (const std::string& c : candidates) {
+      pushUnique(linearCandidates, toLowerCopy(c));
     }
-    for (const std::string& candidate : linearCandidates) {
-      if (lookupViaLinearScan(candidate, dictOffset, dictSize)) {
-        found = true;
-        hitCandidate = candidate;
-        break;
-      }
+    std::string hitLower;
+    if (lookupViaLinearScan(linearCandidates, hitLower, dictOffset, dictSize)) {
+      found = true;
+      hitCandidate = hitLower;
     }
     Serial.printf("[%lu] [DICT] lookup('%s'): linear scan %s (%lums)\n", millis(), queryWord.c_str(),
                   found ? "hit" : "miss", millis() - t1);
@@ -470,21 +698,16 @@ bool StarDictLookup::lookup(const std::string& queryWord, std::string& outDefini
   Serial.printf("[%lu] [DICT] lookup('%s'): matched '%s', dictOffset=%llu dictSize=%u\n", millis(),
                 queryWord.c_str(), hitCandidate.c_str(), static_cast<unsigned long long>(dictOffset), dictSize);
 
-  if (dictSize == 0 || !dictFile_.seekSet(dictOffset)) {
-    Serial.printf("[%lu] [DICT] lookup('%s'): dictSize==0 or seekSet(%llu) failed\n", millis(), queryWord.c_str(),
-                  static_cast<unsigned long long>(dictOffset));
+  bool truncated = false;
+  if (!readDefinition(dictOffset, dictSize, outDefinition, &truncated)) {
+    Serial.printf("[%lu] [DICT] lookup('%s'): definition read failed\n", millis(), queryWord.c_str());
     return false;
   }
-  const uint32_t readSize = std::min(dictSize, kMaxDefinitionBytes);
   if (outTruncated) {
-    *outTruncated = readSize < dictSize;
+    *outTruncated = truncated;
   }
-  outDefinition.resize(readSize);
-  const int readN = dictFile_.read(&outDefinition[0], readSize);
-  if (readN != static_cast<int>(readSize)) {
-    Serial.printf("[%lu] [DICT] lookup('%s'): read %d of %u expected bytes\n", millis(), queryWord.c_str(), readN,
-                  readSize);
-    return false;
-  }
+  cachePut(lowerCleaned, outDefinition, truncated);
+  Serial.printf("[%lu] [DICT] lookup('%s'): total %lums (def %u bytes%s)\n", millis(), queryWord.c_str(),
+                millis() - t0, static_cast<unsigned>(outDefinition.size()), truncated ? ", truncated" : "");
   return true;
 }

--- a/src/dictionary/StarDictLookup.h
+++ b/src/dictionary/StarDictLookup.h
@@ -9,6 +9,13 @@
  * raw definition with no per-entry type prefix - this covers the vast majority of distributed
  * StarDict dictionaries. .syn synonym files are not consulted; lookups are exact/case-insensitive
  * word match only.
+ *
+ * Performance notes (ESP32-C3 + SPI SD):
+ * - .idx is scanned with a multi-KB read buffer (not one-byte SD reads).
+ * - A checkpoint index is built on open for O(log n) bracketed search.
+ * - Sort order is detected (byte-order vs case-insensitive) so the fast path works for both
+ *   common StarDict layouts instead of falling back to a full linear scan.
+ * - Recent definitions are cached in RAM so re-looking-up the same word is effectively free.
  */
 
 #include <SdFat.h>
@@ -32,6 +39,8 @@ class StarDictLookup {
   bool isOpen() const { return isOpen_; }
 
   const std::string& bookname() const { return bookname_; }
+  /** Absolute path of the folder that was last successfully opened (empty if closed). */
+  const std::string& folderPath() const { return folderPath_; }
 
   /** Hard cap on how many raw definition bytes are read from the .dict file (and thus allocated) per
    *  lookup. Some entries in large scholarly dictionaries run 50KB+ of HTML, which can fail to
@@ -49,43 +58,84 @@ class StarDictLookup {
   // Field named entryText, not "word" - Arduino.h #defines a function-like macro `word(...)`
   // that silently breaks member-initializer syntax like `word(std::move(w))`.
   struct Checkpoint {
-    Checkpoint(uint32_t offset, std::string w) : idxOffset(offset), entryText(std::move(w)) {}
+    Checkpoint(uint32_t offset, std::string w, std::string lower)
+        : idxOffset(offset), entryText(std::move(w)), entryLower(std::move(lower)) {}
     uint32_t idxOffset = 0;
     std::string entryText;
+    std::string entryLower;
+  };
+
+  struct DefCacheEntry {
+    std::string keyLower;
+    std::string definition;
+    bool truncated = false;
+  };
+
+  /** Sequential .idx reader with a multi-KB window so scans don't issue one SD transaction per byte. */
+  class IdxCursor {
+   public:
+    IdxCursor(FsFile& file, uint32_t fileSize);
+
+    bool seek(uint32_t absOffset);
+    uint32_t position() const { return pos_; }
+    bool readCString(std::string& out);
+    bool readBE32(uint32_t& out);
+    bool readBE64(uint64_t& out);
+
+   private:
+    bool fillFrom(uint32_t absOffset);
+    bool ensure(uint32_t needBytes);
+    bool readRaw(uint8_t* dest, uint32_t n);
+
+    FsFile& file_;
+    uint32_t fileSize_;
+    static constexpr uint32_t kBufSize = 4096;
+    uint8_t buf_[kBufSize]{};
+    uint32_t bufBase_ = 0;
+    uint32_t bufLen_ = 0;
+    uint32_t pos_ = 0;
   };
 
   bool parseIfo(const std::string& ifoPath);
   bool buildCheckpoints();
-  /** Reads one variable-length .idx entry at idxOffset. Returns false on read failure/EOF.
-   *  nextOffset is the file offset immediately after this entry (for linear-scan advancement).
-   *  The dict-offset field is 4 or 8 bytes on disk depending on the .ifo's idxoffsetbits (see
-   *  use64BitOffsets_ below), hence outDictOffset being 64-bit here. */
-  bool readIdxEntryAt(uint32_t idxOffset, std::string& outEntryText, uint64_t& outDictOffset, uint32_t& outDictSize,
-                      uint32_t& outNextOffset);
-  /** Case-insensitive-first comparison matching StarDict's default collation closely enough for
-   *  practical lookup; returns <0, 0, >0. */
-  static int compareWord(const std::string& a, const std::string& b);
-  /** Checkpoint-based binary search + bounded scan, assuming .idx is sorted in plain byte order
-   *  (the documented StarDict convention). Returns true/fills offsets on an exact match. */
-  bool lookupViaCheckpoints(const std::string& candidate, uint64_t& outDictOffset, uint32_t& outDictSize);
-  /** Full sequential scan of .idx, case-insensitive. Slower but correct regardless of the actual
-   *  on-disk sort order - many third-party-generated StarDict files don't follow the spec's byte-
-   *  order sort (e.g. case-insensitive sort instead), which silently breaks the checkpoint binary
-   *  search above. Used only as a fallback when the fast path finds nothing. */
-  bool lookupViaLinearScan(const std::string& candidate, uint64_t& outDictOffset, uint32_t& outDictSize);
+  /** Reads one variable-length .idx entry starting at cursor's current position. Advances the cursor
+   *  past the entry. dict-offset is 4 or 8 bytes depending on use64BitOffsets_. */
+  bool readIdxEntry(IdxCursor& cur, std::string& outEntryText, uint64_t& outDictOffset, uint32_t& outDictSize);
+
+  /** Comparison matching the detected on-disk sort order. Returns <0, 0, >0. */
+  int compareForSearch(const std::string& a, const std::string& aLower, const std::string& b,
+                       const std::string& bLower) const;
+
+  /** Checkpoint-based binary search + bounded buffered scan. Returns true/fills offsets on match. */
+  bool lookupViaCheckpoints(const std::string& candidate, const std::string& candidateLower, uint64_t& outDictOffset,
+                            uint32_t& outDictSize);
+
+  /** One sequential pass over .idx matching any of the lowercase candidates (first hit wins in
+   *  candidate-list order when multiple match - we track best priority). Buffered; last resort. */
+  bool lookupViaLinearScan(const std::vector<std::string>& candidatesLower, std::string& outHitLower,
+                           uint64_t& outDictOffset, uint32_t& outDictSize);
+
+  bool readDefinition(uint64_t dictOffset, uint32_t dictSize, std::string& outDefinition, bool* outTruncated);
+
+  bool cacheGet(const std::string& keyLower, std::string& outDefinition, bool* outTruncated);
+  void cachePut(const std::string& keyLower, const std::string& definition, bool truncated);
 
   bool isOpen_ = false;
   FsFile idxFile_;
   FsFile dictFile_;
+  std::string folderPath_;
   std::string bookname_;
   std::string sameTypeSequence_;
   uint32_t wordCount_ = 0;
   uint32_t idxFileSize_ = 0;
   // Whether .idx dict-offset fields are 8 bytes (idxoffsetbits=64 in .ifo) instead of the default 4.
-  // Large dictionaries (multi-GB .dict files) need this; getting it wrong misaligns every entry
-  // after the first, since the offset/size fields are fixed-width but the preceding word isn't.
   bool use64BitOffsets_ = false;
+  /** When true, .idx is ordered by case-insensitive word compare (common third-party layout). When
+   *  false, plain strcmp / byte order (documented StarDict convention). */
+  bool caseInsensitiveSort_ = false;
   std::vector<Checkpoint> checkpoints_;
 
-  static constexpr uint32_t kCheckpointStride = 256;
+  static constexpr uint32_t kCheckpointStride = 64;
+  static constexpr size_t kDefCacheSlots = 12;
+  std::vector<DefCacheEntry> defCache_;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -246,10 +246,17 @@ void enterDeepSleep() {
   gpio.startDeepSleep();
 }
 
+void setupDisplayAndHintsPolicy() {
+  // Honor Settings → "Hide button hints" for every call site (hub, settings, reader
+  // dictionary/annotation overlays, side-button chrome, etc.).
+  UiRender::setHintsHiddenFn([]() { return SETTINGS.hideButtonHints != 0; });
+}
+
 void setupDisplayAndFonts() {
   display.begin();
   render.begin();
   FontManager::initialize(render);
+  setupDisplayAndHintsPolicy();
 }
 
 bool handleGlobalPowerRefresh() {

--- a/src/state/ReaderSetting.h
+++ b/src/state/ReaderSetting.h
@@ -96,7 +96,7 @@ class ReaderSetting {
   uint8_t refreshFrequency = 3;  ///< SystemSetting::REFRESH_15 (enum index, not the page count - see getRefreshFrequency())
   uint8_t hyphenationEnabled = 1;    ///< Hyphenation enabled
   uint8_t bionicReadingEnabled = 0;  ///< Bionic Reading enabled
-  /** Reading-guide overlay style: 0 = off, 1 = Grid (vertical lines at 1/3 and 2/3 of content width, a
+  /** Reading-guide overlay style: 0 = off, 1 = Grid (vertical lines at 25% and 75% of content width, a
    *  speed-reading aid), 2 = Notebook (horizontal ruled lines like notebook paper). */
   uint8_t readingGuideLinesEnabled = 0;
 

--- a/src/state/SystemSetting.h
+++ b/src/state/SystemSetting.h
@@ -435,7 +435,7 @@ class SystemSetting {
   uint8_t libraryMode = LIBRARY_GRID;              ///< Library browser display mode
   uint8_t libraryViewMode = LIBRARY_VIEW_FOLDERS;  ///< Last Library browser content view
   uint8_t libraryShelfEnabled = 0;                 ///< Allow cover shelf view in Library
-  /** Hide on-screen button-hint bar on tabbed hub screens (experienced users). */
+  /** Hide on-screen button-hint chrome everywhere (hub, settings, reader overlays, side buttons). */
   uint8_t hideButtonHints = 0;
   /** How many recent books to show on the Recent hub (1–8). */
   uint8_t recentVisibleCount = 9;

--- a/src/system/ScreenComponents.cpp
+++ b/src/system/ScreenComponents.cpp
@@ -126,45 +126,59 @@ void ScreenComponents::drawMenuClockAndBattery(const GfxRenderer& renderer, cons
 }
 
 ScreenComponents::PopupLayout ScreenComponents::drawPopup(const GfxRenderer& renderer, const char* message) {
-  constexpr int margin = 15;
+  // Compact bottom status chip (not a center modal): leaves most of the page readable and matches
+  // how e-reader firmware usually reports short blocking work.
+  constexpr int marginX = 14;
+  constexpr int marginY = 10;
+  constexpr int bottomGap = 18;
+  constexpr int fontId = ATKINSON_HYPERLEGIBLE_10_FONT_ID;
 
-  const int textWidth = renderer.text.getWidth(ATKINSON_HYPERLEGIBLE_12_FONT_ID, message);
-  const int textHeight = renderer.text.getLineHeight(ATKINSON_HYPERLEGIBLE_12_FONT_ID);
-  const int w = textWidth + margin * 2;
-  const int h = textHeight + margin * 2;
-  const int y = std::max(0, renderer.getScreenHeight() * 2 / 5);
-  const int x = (renderer.getScreenWidth() - w) / 2;
+  const int screenW = renderer.getScreenWidth();
+  const int screenH = renderer.getScreenHeight();
+  const int maxLabelW = std::max(8, screenW - 2 * marginX - 24);
+  const std::string msgShown = renderer.text.truncate(fontId, message ? message : "", maxLabelW);
+  const int textWidth = renderer.text.getWidth(fontId, msgShown.c_str());
+  const int textHeight = renderer.text.getLineHeight(fontId);
+  const int w = std::min(screenW - 8, textWidth + marginX * 2);
+  const int h = textHeight + marginY * 2;
+  const int x = (screenW - w) / 2;
+  const int y = std::max(0, screenH - h - bottomGap);
 
-  renderer.rectangle.fill(x - 2, y - 2, w + 4, h + 4, true, true);
-  renderer.rectangle.fill(x, y, w, h, true, true);
+  renderer.rectangle.fill(x - 1, y - 1, w + 2, h + 2, true, true);
+  renderer.rectangle.fill(x, y, w, h, false, true);
+  renderer.rectangle.render(x, y, w, h, true, true);
 
   const int textX = x + (w - textWidth) / 2;
-  const int textY = y + margin - 2;
-  renderer.text.render(ATKINSON_HYPERLEGIBLE_12_FONT_ID, textX, textY, message, false);
-  renderer.displayBuffer();
+  const int textY = y + marginY - 1;
+  renderer.text.render(fontId, textX, textY, msgShown.c_str(), true);
+  renderer.displayBuffer(HalDisplay::FAST_REFRESH);
   return {x, y, w, h};
 }
 
 void ScreenComponents::fillPopupProgress(const GfxRenderer& renderer, const PopupLayout& layout, const int progress) {
-  constexpr int barHeight = 4;
-  const int barWidth = layout.width - 30;
+  // Thin progress underline under the bottom status chip.
+  constexpr int barHeight = 3;
+  const int barWidth = std::max(8, layout.width - 16);
   const int barX = layout.x + (layout.width - barWidth) / 2;
-  const int barY = layout.y + layout.height - 10;
+  const int barY = layout.y + layout.height - 6;
 
   const int clamped = std::max(0, std::min(100, progress));
-  int fillWidth = barWidth * clamped / 100;
+  const int fillWidth = barWidth * clamped / 100;
 
-  renderer.rectangle.fill(barX, barY, fillWidth, barHeight, true);
+  renderer.rectangle.fill(barX, barY, barWidth, barHeight, false);
+  if (fillWidth > 0) {
+    renderer.rectangle.fill(barX, barY, fillWidth, barHeight, true);
+  }
 
   renderer.displayBuffer(HalDisplay::FAST_REFRESH);
 }
 
 namespace {
 
-constexpr int kLoadProgSideMargin = 20;
-constexpr int kLoadProgInnerPad = 12;
-constexpr int kLoadProgBarH = 10;
-constexpr int kLoadProgGapLabelToBar = 10;
+constexpr int kLoadProgSideMargin = 16;
+constexpr int kLoadProgInnerPad = 10;
+constexpr int kLoadProgBarH = 6;
+constexpr int kLoadProgGapLabelToBar = 6;
 
 void paintLoadingProgressBarRow(const GfxRenderer& renderer, const ScreenComponents::LoadingProgressLayout& L,
                                 const int progressPercent0to100) {
@@ -172,11 +186,12 @@ void paintLoadingProgressBarRow(const GfxRenderer& renderer, const ScreenCompone
   const int innerW = std::max(1, L.barW - 2);
   const int fillW = innerW * clamped / 100;
 
+  // Light panel: empty track is white, fill + outline are ink.
   renderer.rectangle.fill(L.barX + 1, L.barY + 1, innerW, L.barH - 2, false);
   if (fillW > 0) {
     renderer.rectangle.fill(L.barX + 1, L.barY + 1, fillW, L.barH - 2, true);
   }
-  renderer.rectangle.render(L.barX, L.barY, L.barW, L.barH, false);
+  renderer.rectangle.render(L.barX, L.barY, L.barW, L.barH, true);
 }
 
 }  // namespace
@@ -184,31 +199,36 @@ void paintLoadingProgressBarRow(const GfxRenderer& renderer, const ScreenCompone
 ScreenComponents::LoadingProgressLayout ScreenComponents::LoadingProgress::show(const GfxRenderer& renderer,
                                                                                 const char* message,
                                                                                 const int progressPercent0to100) {
+  // Bottom status strip with a slim progress bar — same visual language as drawPopup, so layout
+  // updates ("Updating layout") don't plant a heavy center modal over the page mid-reflow.
   const int clamped = std::max(0, std::min(100, progressPercent0to100));
   const int screenW = renderer.getScreenWidth();
-  constexpr int labelFontId = ATKINSON_HYPERLEGIBLE_12_FONT_ID;
+  const int screenH = renderer.getScreenHeight();
+  constexpr int labelFontId = ATKINSON_HYPERLEGIBLE_10_FONT_ID;
   const int lhLabel = renderer.text.getLineHeight(labelFontId);
 
-  constexpr int kMinBarW = 40;
+  constexpr int kMinBarW = 80;
+  constexpr int kBottomGap = 16;
   const int labelMaxForMeasure = std::max(8, screenW - 2 * kLoadProgSideMargin - 2 * kLoadProgInnerPad);
   const std::string msgShown = renderer.text.truncate(labelFontId, message ? message : "", labelMaxForMeasure);
   const int labelW = renderer.text.getWidth(labelFontId, msgShown.c_str());
 
   const int innerContentW = std::max(labelW, kMinBarW);
-  const int panelW = std::min(screenW - 4, innerContentW + 2 * kLoadProgInnerPad);
+  const int panelW = std::min(screenW - 8, std::max(innerContentW + 2 * kLoadProgInnerPad, screenW / 2));
   const int panelX = (screenW - panelW) / 2;
   const int innerW = panelW - 2 * kLoadProgInnerPad;
   const int barW = std::max(kMinBarW, innerW);
   const int panelH = kLoadProgInnerPad + lhLabel + kLoadProgGapLabelToBar + kLoadProgBarH + kLoadProgInnerPad;
-  const int panelY = std::max(0, renderer.getScreenHeight() * 2 / 5 - panelH);
+  const int panelY = std::max(0, screenH - panelH - kBottomGap);
   const int labelX = panelX + (panelW - labelW) / 2;
   const int labelY = panelY + kLoadProgInnerPad;
   const int barX = panelX + kLoadProgInnerPad;
   const int barY = labelY + lhLabel + kLoadProgGapLabelToBar;
 
-  renderer.rectangle.fill(panelX - 2, panelY - 2, panelW + 4, panelH + 4, true, true);
-  renderer.rectangle.fill(panelX, panelY, panelW, panelH, true, true);
-  renderer.text.render(labelFontId, labelX, labelY, msgShown.c_str(), false);
+  renderer.rectangle.fill(panelX - 1, panelY - 1, panelW + 2, panelH + 2, true, true);
+  renderer.rectangle.fill(panelX, panelY, panelW, panelH, false, true);
+  renderer.rectangle.render(panelX, panelY, panelW, panelH, true, true);
+  renderer.text.render(labelFontId, labelX, labelY, msgShown.c_str(), true);
 
   LoadingProgressLayout L;
   L.panelX = panelX;
@@ -221,7 +241,7 @@ ScreenComponents::LoadingProgressLayout ScreenComponents::LoadingProgress::show(
   L.barH = kLoadProgBarH;
 
   paintLoadingProgressBarRow(renderer, L, clamped);
-  renderer.displayBuffer();
+  renderer.displayBuffer(HalDisplay::FAST_REFRESH);
 
   return L;
 }

--- a/src/system/ScreenComponents.h
+++ b/src/system/ScreenComponents.h
@@ -33,11 +33,15 @@ class ScreenComponents {
                                       bool showBatteryPercentage = true);
   static void drawBookProgressBar(const GfxRenderer& renderer, size_t bookProgress);
 
+  /**
+   * Compact bottom status chip for short blocking work (e.g. "Opening dictionary...", "Closing book").
+   * Uses a fast refresh so it feels like a toast rather than a full-page modal.
+   */
   static PopupLayout drawPopup(const GfxRenderer& renderer, const char* message);
 
   static void fillPopupProgress(const GfxRenderer& renderer, const PopupLayout& layout, int progress);
 
-  /** Geometry for {@link LoadingProgress}: label on top, full-width progress bar below. */
+  /** Geometry for {@link LoadingProgress}: bottom strip with label + slim progress bar. */
   struct LoadingProgressLayout {
     int panelX = 0;
     int panelY = 0;
@@ -50,7 +54,8 @@ class ScreenComponents {
   };
 
   /**
-   * Bottom popup: text label and progress bar below.
+   * Bottom status strip with a progress bar (layout rebuilds, chapter loads, stats, etc.).
+   * Intentionally not a center modal — keeps the page context visible during longer work.
    */
   struct LoadingProgress {
     static LoadingProgressLayout show(const GfxRenderer& renderer, const char* message, int progressPercent0to100);

--- a/src/system/UiTheme.cpp
+++ b/src/system/UiTheme.cpp
@@ -154,6 +154,8 @@ int UiTheme::drawPageHeader(const GfxRenderer& renderer, const char* title, cons
 
 void UiTheme::drawButtonHints(const GfxRenderer& renderer, const int fontId, const char* btn1, const char* btn2,
                               const char* btn3, const char* btn4) const {
+  // Hide-button-hints is enforced inside UiRender::buttonHints (global policy).
+  // Hub chrome: when main tabs sit on the bottom row, they replace the hint bar.
   if (!mainTabsAtBottom()) {
     renderer.ui.buttonHints(fontId, btn1, btn2, btn3, btn4);
   }


### PR DESCRIPTION
## Summary

* Rebase onto main (1.0.19) so this PR is mergeable again.
* **Hide button hints** is enforced globally via `UiRender` (hub, settings, dictionary/annotation overlays, side buttons) — not only tabbed hub chrome.
* **Guide Lines → Grid** uses vertical guides at **25% / 75%** of content width (Notebook mode from 1.0.19 unchanged).
* **Dictionary lookups** are optimized for interactive use:
  * Buffered multi-KB `.idx` reads (no more one-byte SD scans)
  * Denser checkpoints + sort-order detection (byte-order vs case-insensitive) so third-party dicts stay on the fast path
  * Small in-RAM definition cache; dictionary stays warm for the book session
  * Cold open shows "Opening dictionary..."; warm lookups skip the toast entirely
* **Loading / status UI**: center modals become compact **bottom status chips** with fast refresh ("Updating layout", popups, progress strips).

## Additional Context

* Target: warm dictionary lookups near-instant (ideally under ~100ms after first open); cold open still pays one-time checkpoint build.
* Layout rebuilds (orientation / preset) still reflow the chapter — that cost is inherent; the toast is now less intrusive while it runs.
* Performance logging remains under `[DICT]` serial tags for on-device timing.

## Test plan

- [ ] Enable **Hide button hints**; confirm no bottom/side hint chrome on hub, settings, dictionary, annotation.
- [ ] With hints off, dictionary/annotation side hints still appear.
- [ ] Guide Lines → **Grid**: lines at ~quarter and three-quarter of the text column; **Notebook** still draws ruled lines under text.
- [ ] First dictionary lookup may briefly show "Opening dictionary..."; second lookup should feel instant with no toast.
- [ ] Apply a preset / change orientation: bottom "Updating layout" strip (not a center modal); page still rebuilds correctly.
- [ ] Serial monitor: `[DICT] fast path hit` and total times on warm lookups.

---

### AI Usage

Did you use AI tools to help write this code? **YES**