### PR TITLE
fix: Epub - render markers in <ol> numbered lists

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: [obijuankenobiii]
+github: obijuankenobiii
 ko_fi: obijuankenobiii

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 github: [obijuankenobiii]
-ko_fi: obijuankenobi02
+ko_fi: obijuankenobiii

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1883,8 +1883,6 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       }
       if (tagLower == "ul" || tagLower == "ol") {
         self->listNoIndentDepths_.push_back(self->depth);
-      }
-      if (tagLower == "ul") {
         self->ulBulletVisibleStack.push_back(!self->css().isListStyleNone(tagLower, classAttr, idAttr, styleAttr));
         self->ulBulletVisibleDepths.push_back(self->depth);
       } else if (tagLower == "li") {


### PR DESCRIPTION
## Summary

Currently `<ol>` lists in EPUB look like text paragraphs, where it's impossible to tell multi-paragraph items apart.
This at least marks items somehow, even if not exactly how they're supposed to be (and idk if numbering there is ever useful tbh).

Code tweak is to use same logic as for `<ul>` lists.

---

### AI Usage

Did you use AI tools to help write this code? _**NO**_
