### PR TITLE
Fix Go To Percent double-stepping on one press

### DIFF
--- a/src/activity/reader/Epub/MenuDrawer.cpp
+++ b/src/activity/reader/Epub/MenuDrawer.cpp
@@ -819,25 +819,33 @@ void MenuDrawer::handlePercentInput(const MappedInputManager& input) {
     return;
   }
 
-  const uint32_t currentTime = xTaskGetTickCount();
-  if (currentTime - lastInputTime < pdMS_TO_TICKS(150)) {
-    return;
-  }
-
   int delta = 0;
-  if (input.isPressed(MappedInputManager::Button::Left)) {
+  if (input.wasPressed(MappedInputManager::Button::Left)) {
     delta = -1;
-  } else if (input.isPressed(MappedInputManager::Button::Right)) {
+  } else if (input.wasPressed(MappedInputManager::Button::Right)) {
     delta = 1;
-  } else if (input.isPressed(MappedInputManager::Button::Up)) {
+  } else if (input.wasPressed(MappedInputManager::Button::Up)) {
     delta = 10;
-  } else if (input.isPressed(MappedInputManager::Button::Down)) {
+  } else if (input.wasPressed(MappedInputManager::Button::Down)) {
     delta = -10;
+  } else if (input.getHeldTime() > 700) {
+    const uint32_t currentTime = xTaskGetTickCount();
+    if (currentTime - lastInputTime >= pdMS_TO_TICKS(150)) {
+      if (input.isPressed(MappedInputManager::Button::Left)) {
+        delta = -1;
+      } else if (input.isPressed(MappedInputManager::Button::Right)) {
+        delta = 1;
+      } else if (input.isPressed(MappedInputManager::Button::Up)) {
+        delta = 10;
+      } else if (input.isPressed(MappedInputManager::Button::Down)) {
+        delta = -10;
+      }
+    }
   }
 
   if (delta != 0) {
     percentValue_ = std::max(0, std::min(100, percentValue_ + delta));
-    lastInputTime = currentTime;
+    lastInputTime = xTaskGetTickCount();
     renderWithRefresh();
   }
 }


### PR DESCRIPTION
Tapping Left/Right in **Go To Percent** currently moves 2% (Up/Down move 20%) because `handlePercentInput()` keys off `isPressed()` plus a 150ms cooldown. The first tap is still held when the next loop runs, so it counts as a second step.

This switches the first step to `wasPressed()` (one edge = one step). Repeat only starts after a 700ms hold, then uses the existing 150ms cadence. Same 1% / 10% steps as before.

Single-file change: `MenuDrawer::handlePercentInput()`.

## Test on device
- EPUB menu → Go To Percent
- Tap Right once → 1%, not 2%. Tap Down once → 10%, not 20%
- Hold Right: one step immediately, then repeat after ~700ms
- Confirm still jumps to the selected percent