### PR TITLE
Fix power-button sleep opening the selected book

### DIFF
--- a/src/activity/Activity.h
+++ b/src/activity/Activity.h
@@ -95,4 +95,10 @@ class Activity {
    * ReaderActivity opts out because book readers have their own short-power behavior setting.
    */
   virtual bool allowGlobalPowerRefresh() { return true; }
+
+  /**
+   * True while a book (or other document) is actually open. Sleep-from-home must not
+   * load the last book's cover as if the reader had been opened.
+   */
+  virtual bool isReadingActivity() const { return false; }
 };

--- a/src/activity/reader/Epub/EpubActivity.h
+++ b/src/activity/reader/Epub/EpubActivity.h
@@ -287,6 +287,8 @@ class EpubActivity final : public ActivityWithSubactivity {
   void onPercentDrawerSelected(int percent);
   void jumpToPercent(int percent);
 
+  bool isReadingActivity() const override { return true; }
+
   void displayBookTitle();
   void drawLoadingScreen();
   void preloadNextSection();

--- a/src/activity/reader/ReaderActivity.h
+++ b/src/activity/reader/ReaderActivity.h
@@ -138,4 +138,5 @@ class ReaderActivity final : public ActivityWithSubactivity {
    */
   void onEnter() override;
   bool allowGlobalPowerRefresh() override { return false; }
+  bool isReadingActivity() const override { return true; }
 };

--- a/src/activity/reader/TxtReaderActivity.h
+++ b/src/activity/reader/TxtReaderActivity.h
@@ -60,4 +60,5 @@ class TxtReaderActivity final : public ActivityWithSubactivity {
   void onEnter() override;
   void onExit() override;
   void loop() override;
+  bool isReadingActivity() const override { return true; }
 };

--- a/src/activity/reader/XtcReaderActivity.h
+++ b/src/activity/reader/XtcReaderActivity.h
@@ -72,4 +72,5 @@ class XtcReaderActivity final : public ActivityWithSubactivity {
   void onEnter() override;
   void onExit() override;
   void loop() override;
+  bool isReadingActivity() const override { return true; }
 };

--- a/src/activity/system/SleepActivity.cpp
+++ b/src/activity/system/SleepActivity.cpp
@@ -315,7 +315,11 @@ void SleepActivity::onEnter() {
       renderCustomSleepScreen();
       break;
     case SystemSetting::SLEEP_SCREEN_MODE::COVER:
-      renderCoverSleepScreen();
+      if (fromReader_) {
+        renderCoverSleepScreen();
+      } else {
+        renderCustomSleepScreen();
+      }
       break;
     case SystemSetting::SLEEP_SCREEN_MODE::DATETIME:
       if (dateTimeSleepScreenAvailable()) {

--- a/src/activity/system/SleepActivity.h
+++ b/src/activity/system/SleepActivity.h
@@ -27,8 +27,8 @@ class SleepActivity final : public Activity {
    * @param renderer Graphics renderer for drawing the sleep screen
    * @param mappedInput Input manager for handling wake-up events
    */
-  explicit SleepActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
-      : Activity("Sleep", renderer, mappedInput) {}
+  explicit SleepActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, bool fromReader = false)
+      : Activity("Sleep", renderer, mappedInput), fromReader_(fromReader) {}
 
   /**
    * @brief Initializes and renders the sleep screen when activity becomes active.
@@ -39,6 +39,7 @@ class SleepActivity final : public Activity {
   void onEnter() override;
 
  private:
+  bool fromReader_ = false;
   /**
    * @brief Renders the default sleep screen with Corgi logo.
    *

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -254,7 +254,8 @@ void normalizeUnavailableClockSettings() {
 
 void enterDeepSleep() {
   normalizeUnavailableClockSettings();
-  switchTo<SleepActivity>(render, input);
+  const bool fromReader = currentActivity && currentActivity->isReadingActivity();
+  switchTo<SleepActivity>(render, input, fromReader);
   display.deepSleep();
   gpio.startDeepSleep();
 }
@@ -434,8 +435,16 @@ void loop() {
     return;
   }
 
-  if (gpio.isPressed(HalGPIO::BTN_POWER) && gpio.getHeldTime() > SETTINGS.getPowerButtonDuration()) {
+  const bool powerHeld = gpio.isPressed(HalGPIO::BTN_POWER);
+  if (powerHeld && gpio.getHeldTime() > SETTINGS.getPowerButtonDuration()) {
     enterDeepSleep();
+    return;
+  }
+
+  // Ignore other input while power is held so a long-press-to-sleep cannot also
+  // open the selected home/library book (GPIO bounce / Confirm during the hold).
+  if (powerHeld) {
+    delay(10);
     return;
   }
 


### PR DESCRIPTION
Two related sleep bugs:

1. Long-pressing power on Home/Recents/Library also opens the highlighted book. The power hold is long enough for Confirm (or GPIO bounce) to fire in the same loop.
2. Cover sleep mode always rendered the last book cover, even if you slept from Home, so it looked like the reader had opened.

`loop()` now returns while `BTN_POWER` is held, so nothing else is processed until sleep starts. `Activity::isReadingActivity()` is false by default; EPUB/TXT/XTC/PDF readers override it. `SleepActivity` only uses the cover sleep screen when that flag is true.

## Test on device
- Home or Recents, highlight a book, long-press power → device sleeps, book does **not** open
- Cover sleep mode, sleep from Home → default/custom sleep art, not the last cover
- Same setting, sleep from an open EPUB → cover still shows
- Short power press in the reader is unchanged (readers still opt out of global power-refresh)