### PR TITLE
Fix finished-book detection and recents Finished label

### DIFF
--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -102,3 +102,17 @@ class Epub {
   size_t getBookSize() const;
   float calculateProgress(int currentSpineIndex, float currentSpineRead) const;
 };
+
+/** Fraction of the current spine that has been read. Last page is 1.0, not (n-1)/n. */
+inline float epubSpineReadFraction(int currentPage, int pageCount) {
+  if (pageCount <= 0) {
+    return 0.0f;
+  }
+  if (currentPage < 0) {
+    currentPage = 0;
+  }
+  if (currentPage + 1 >= pageCount) {
+    return 1.0f;
+  }
+  return static_cast<float>(currentPage + 1) / static_cast<float>(pageCount);
+}

--- a/src/activity/Activity.h
+++ b/src/activity/Activity.h
@@ -95,4 +95,10 @@ class Activity {
    * ReaderActivity opts out because book readers have their own short-power behavior setting.
    */
   virtual bool allowGlobalPowerRefresh() { return true; }
+
+  /**
+   * True while a book (or other document) is actually open. Sleep-from-home must not
+   * load the last book's cover as if the reader had been opened.
+   */
+  virtual bool isReadingActivity() const { return false; }
 };

--- a/src/activity/page/RecentActivity.cpp
+++ b/src/activity/page/RecentActivity.cpp
@@ -6,6 +6,7 @@
 #include "RecentActivity.h"
 
 #include <Bitmap.h>
+#include <EpdFontFamily.h>
 #include <GfxRenderer.h>
 #include <HalGPIO.h>
 #include <HardwareSerial.h>
@@ -42,6 +43,7 @@
 #include "system/Fonts.h"
 #include "system/MappedInputManager.h"
 #include "system/UiTheme.h"
+#include "util/BookDisplayTitle.h"
 #include "util/StringUtils.h"
 
 extern bool sdCardAvailable;
@@ -81,10 +83,20 @@ static std::string formatTitle(const std::string& title) {
 }
 
 static std::string bookDisplayTitle(const RecentBook& book) {
-  if (!book.title.empty()) {
-    return book.title;
+  const std::string fallback = book.title.empty() ? book.path : book.title;
+  return BookDisplayTitle::resolve(book.path, fallback);
+}
+
+static bool recentBookFinished(const RecentBook& book) {
+  if (book.progress >= 0.995f) {
+    return true;
   }
-  return formatTitle(getBaseFilename(book.path));
+  BookState::Book state;
+  return BOOK_STATE.findBook(book.path, state) && state.isFinished;
+}
+
+static float recentDisplayProgress(const RecentBook& book) {
+  return recentBookFinished(book) ? 1.0f : book.progress;
 }
 
 constexpr unsigned long GO_HOME_MS = 1000;
@@ -219,8 +231,12 @@ static void drawProgressBadge(const GfxRenderer& renderer, const IconRect& cover
   if (progress < 0.0f || progress > 1.0f) {
     return;
   }
-  char label[8];
-  snprintf(label, sizeof(label), "%d%%", static_cast<int>(progress * 100.0f + 0.5f));
+  char label[12];
+  if (progress >= 0.995f) {
+    snprintf(label, sizeof(label), "100%%");
+  } else {
+    snprintf(label, sizeof(label), "%d%%", static_cast<int>(progress * 100.0f + 0.5f));
+  }
   constexpr int font = ATKINSON_HYPERLEGIBLE_8_FONT_ID;
   const int textW = renderer.text.getWidth(font, label);
   const int textH = renderer.text.getLineHeight(font);
@@ -473,9 +489,6 @@ void RecentActivity::loadRecentBooks(const bool resetScroll) {
 
   for (size_t i = 0; i < allBooks.size() && addedCount < maxShow; ++i) {
     const auto& book = allBooks[i];
-    if (!SdMan.exists(book.path.c_str())) {
-      continue;
-    }
     recentBooks.push_back(book);
     recentStats_.push_back(CachedRecentStats{});
     addedCount++;
@@ -810,14 +823,18 @@ void RecentActivity::renderGridItem(int gridX, int gridY, int startY, const Rece
                         ATKINSON_HYPERLEGIBLE_10_FONT_ID, selected);
 
   if (book.progress >= 0.0f && book.progress <= 1.0f) {
+    const float prog = recentDisplayProgress(book);
     int barX = drawX + 15;
     constexpr int kGridProgressBottomInset = 16;
     int barY = drawY + drawH - kGridProgressBottomInset;
     int barW = drawW - 30;
     int barH = 6;
-    char pText[8];
-    int percent = static_cast<int>(book.progress * 100.0f + 0.5f);
-    snprintf(pText, sizeof(pText), "%d%%", percent);
+    char pText[12];
+    if (recentBookFinished(book)) {
+      snprintf(pText, sizeof(pText), "Finished");
+    } else {
+      snprintf(pText, sizeof(pText), "%d%%", static_cast<int>(prog * 100.0f + 0.5f));
+    }
     constexpr int kPctFont = ATKINSON_HYPERLEGIBLE_8_FONT_ID;
     const int pW = renderer.text.getWidth(kPctFont, pText);
     const int pH = renderer.text.getLineHeight(kPctFont);
@@ -829,8 +846,8 @@ void RecentActivity::renderGridItem(int gridX, int gridY, int startY, const Rece
     renderer.rectangle.fill(barX, barY, barW, barH, false);
     renderer.rectangle.render(barX, barY, barW, barH, true);
 
-    if (book.progress > 0.0f) {
-      int fillW = static_cast<int>(barW * book.progress + 0.5f);
+    if (prog > 0.0f) {
+      int fillW = static_cast<int>(barW * prog + 0.5f);
       renderer.rectangle.fill(barX, barY, fillW, barH);
     }
     renderer.text.render(kPctFont, pX, pY, pText);

--- a/src/activity/page/components/recent/Flow.ipp
+++ b/src/activity/page/components/recent/Flow.ipp
@@ -11,6 +11,12 @@ void RecentActivity::renderFlow() {
 
   int currentIndex = selectorIndex;
   int totalBooks = (int)recentBooks.size();
+  if (currentIndex < 0) {
+    currentIndex = 0;
+  }
+  if (currentIndex >= totalBooks) {
+    currentIndex = totalBooks - 1;
+  }
 
   int carouselW = screenW;
   int carouselH = 340;
@@ -33,15 +39,14 @@ void RecentActivity::renderFlow() {
   int rightX = centerX + centerW + 20;
   int sideY = centerY + (centerH - sideH) / 2;
 
-  if (currentIndex > 0) {
-    const RecentBook& leftBook = recentBooks[currentIndex - 1];
+  if (totalBooks > 1) {
+    const int leftIndex = (currentIndex + totalBooks - 1) % totalBooks;
+    const int rightIndex = (currentIndex + 1) % totalBooks;
+    const RecentBook& leftBook = recentBooks[leftIndex];
     renderer.rectangle.fill(leftX, sideY, sideW, sideH, false, rr);
     drawRecentThumbnailAt(leftX, sideY, sideW, sideH, leftBook.cachePath, bookDisplayTitle(leftBook),
                           ATKINSON_HYPERLEGIBLE_10_FONT_ID, true);
-  }
-
-  if (currentIndex + 1 < totalBooks) {
-    const RecentBook& rightBook = recentBooks[currentIndex + 1];
+    const RecentBook& rightBook = recentBooks[rightIndex];
     renderer.rectangle.fill(rightX, sideY, sideW, sideH, false, rr);
     drawRecentThumbnailAt(rightX, sideY, sideW, sideH, rightBook.cachePath, bookDisplayTitle(rightBook),
                           ATKINSON_HYPERLEGIBLE_10_FONT_ID, true);
@@ -77,22 +82,25 @@ void RecentActivity::renderFlow() {
   int authorY = statsY + renderer.text.getLineHeight(ATKINSON_HYPERLEGIBLE_18_FONT_ID) - 5;
   renderer.text.render(ATKINSON_HYPERLEGIBLE_12_FONT_ID, statsX, authorY, currentBook.author.c_str());
 
-  float progress = hasStats ? stats.progressPercent : (currentBook.progress * 100.0f);
-  if (progress >= 0) {
+  const float prog = recentDisplayProgress(currentBook);
+  if (prog >= 0) {
     int barY = authorY + renderer.text.getLineHeight(ATKINSON_HYPERLEGIBLE_12_FONT_ID) + 20;
     int barW = (screenW - 60) * 0.5;
     int barH = 6;
 
     renderer.rectangle.fill(statsX, barY, barW, barH, false);
     renderer.rectangle.render(statsX, barY, barW, barH, true);
-    if (progress > 0) {
-      int fillW = (int)(barW * (progress / 100.0f));
+    if (prog > 0) {
+      int fillW = (int)(barW * prog);
       renderer.rectangle.fill(statsX, barY, fillW, barH);
     }
 
-    char percentText[8];
-    int percent = (int)(progress + 0.5f);
-    snprintf(percentText, sizeof(percentText), "%d%%", percent);
+    char percentText[12];
+    if (recentBookFinished(currentBook)) {
+      snprintf(percentText, sizeof(percentText), "Finished");
+    } else {
+      snprintf(percentText, sizeof(percentText), "%d%%", (int)(prog * 100.0f + 0.5f));
+    }
     renderer.text.render(ATKINSON_HYPERLEGIBLE_12_FONT_ID, statsX + barW + 12, barY - 13, percentText);
   }
 

--- a/src/activity/page/components/recent/Grid.ipp
+++ b/src/activity/page/components/recent/Grid.ipp
@@ -75,7 +75,7 @@ void RecentActivity::renderIcons(int startY) {
       const RecentBook& b = recentBooks[static_cast<size_t>(bookIdx)];
       drawRecentCoverFitAt(fittedCover.x, fittedCover.y, fittedCover.w, fittedCover.h, b.cachePath, bookDisplayTitle(b),
                            ATKINSON_HYPERLEGIBLE_10_FONT_ID);
-      drawProgressBadge(renderer, fittedCover, b.progress);
+      drawProgressBadge(renderer, fittedCover, recentDisplayProgress(b));
       const IconRect coverFrame = inflateIconRect(fittedCover, 5);
       if (selected) {
         renderThickIconRect(renderer, coverFrame, rr, 3);

--- a/src/activity/page/components/recent/List.ipp
+++ b/src/activity/page/components/recent/List.ipp
@@ -61,12 +61,16 @@ void RecentActivity::renderList(int startY) {
       lastTextBottom = tyA + lhA;
     }
 
-    float prog = book.progress;
+    float prog = recentDisplayProgress(book);
     if (prog < 0.f || prog > 1.f) {
       prog = 0.f;
     }
     char pctBuf[12];
-    snprintf(pctBuf, sizeof(pctBuf), "%.0f%%", static_cast<double>(prog * 100.f));
+    if (recentBookFinished(book)) {
+      snprintf(pctBuf, sizeof(pctBuf), "Finished");
+    } else {
+      snprintf(pctBuf, sizeof(pctBuf), "%.0f%%", static_cast<double>(prog * 100.f));
+    }
     const int fontPct = ATKINSON_HYPERLEGIBLE_8_FONT_ID;
     const int pctW = renderer.text.getWidth(fontPct, pctBuf);
     constexpr int barH = 6;

--- a/src/activity/reader/Epub/EpubActivity.cpp
+++ b/src/activity/reader/Epub/EpubActivity.cpp
@@ -18,6 +18,7 @@
 #include <time.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -36,6 +37,7 @@
 #include "state/BookProgress.h"
 #include "state/BookSetting.h"
 #include "state/BookState.h"
+#include "util/BookDisplayTitle.h"
 #include "state/EpubNotesIndex.h"
 #include "state/RecentBooks.h"
 #include "state/Session.h"
@@ -59,6 +61,37 @@ static std::string chapterTitleForSpine(const Epub* epub, int spineIndex) {
     return epub->getTocItem(tocIndex).title;
   }
   return "Chapter " + std::to_string(spineIndex + 1);
+}
+
+bool looksLikeBackMatterTitle(const std::string& title) {
+  std::string lower;
+  lower.reserve(title.size());
+  for (unsigned char c : title) {
+    lower.push_back(static_cast<char>(std::tolower(c)));
+  }
+  static const char* kKeys[] = {
+      "about the author",  "about the authors", "also by",     "other books by", "by the same author",
+      "copyright",         "acknowledg",        "bibliography", "works cited",    "endnotes",
+      "advertisement",     "preview of",        "excerpt from", "discussion questions",
+      "reading group",     "teaser",            "sneak peek",   "about this book", "colophon",
+      "more from",         "newsletter",        "credits"};
+  for (const char* key : kKeys) {
+    if (lower.find(key) != std::string::npos) {
+      return true;
+    }
+  }
+  static const char* kExact[] = {"index", "copyright", "credits", "colophon"};
+  for (const char* key : kExact) {
+    if (lower == key) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string cleanedEpubTitle(const Epub& book) {
+  const std::string title = BookDisplayTitle::clean(book.getTitle());
+  return title.empty() ? book.getTitle() : title;
 }
 }  // namespace
 
@@ -242,9 +275,6 @@ void EpubActivity::handleChapterLoadFailure() {
   if (epub) {
     epub->clearCache();
   }
-  if (bookProgress) {
-    bookProgress->remove();
-  }
   onGoBack();
 }
 
@@ -417,13 +447,13 @@ void EpubActivity::loadProgress() {
   BookProgress::Data data;
   int totalSpines = epub->getSpineItemsCount();
 
-  if (bookProgress->load(data) && bookProgress->validate(data, totalSpines)) {
+  if (bookProgress->load(data)) {
+    bookProgress->sanitize(data, totalSpines);
     currentSpineIndex = data.spineIndex;
     nextPageNumber = data.pageNumber;
     cachedSpineIndex = currentSpineIndex;
     cachedChapterTotalPageCount = data.chapterPageCount;
   } else {
-    bookProgress->remove();
     currentSpineIndex = 0;
     nextPageNumber = 0;
     cachedSpineIndex = 0;
@@ -437,8 +467,110 @@ void EpubActivity::loadProgress() {
  * @param currentPage Current page number
  * @param pageCount Total pages in current chapter
  */
+int EpubActivity::lastStorySpineIndex() const {
+  if (!epub) {
+    return 0;
+  }
+  const int last = epub->getSpineItemsCount() - 1;
+  if (last < 0) {
+    return 0;
+  }
+  int storyEnd = -1;
+  const int tocCount = epub->getTocItemsCount();
+  for (int i = 0; i < tocCount; ++i) {
+    const auto toc = epub->getTocItem(i);
+    if (toc.spineIndex < 0 || toc.spineIndex > last) {
+      continue;
+    }
+    if (looksLikeBackMatterTitle(toc.title)) {
+      continue;
+    }
+    if (toc.spineIndex > storyEnd) {
+      storyEnd = toc.spineIndex;
+    }
+  }
+  // Only skip back matter when the detected story end is actually near the end of the
+  // spine. Aggressive TOC matching (e.g. "credits" in a chapter title) used to report
+  // spine 0 as "the end", which then marked mid-book positions as finished and reset
+  // progress on reopen.
+  if (storyEnd >= 0 && storyEnd >= (last * 3) / 4) {
+    return storyEnd;
+  }
+  return last;
+}
+
+bool EpubActivity::isAtEndOfStory() const {
+  if (!epub || dictUi_.isActive() || annUi_.isActive()) {
+    return false;
+  }
+  const int total = epub->getSpineItemsCount();
+  if (total <= 0) {
+    return false;
+  }
+  if (currentSpineIndex >= total) {
+    return true;
+  }
+  const int storyEnd = lastStorySpineIndex();
+  if (currentSpineIndex != storyEnd) {
+    return false;
+  }
+  return section && section->pageCount > 0 && section->currentPage >= section->pageCount - 1;
+}
+
+void EpubActivity::markBookFinished() {
+  if (!epub || dictUi_.isActive() || annUi_.isActive()) {
+    return;
+  }
+  BOOK_STATE.setFinished(epub->getPath(), true);
+
+  const int total = epub->getSpineItemsCount();
+  int spine = currentSpineIndex;
+  int page = 0;
+  int count = 1;
+  if (section && section->pageCount > 0) {
+    count = section->pageCount;
+    page = section->currentPage;
+  } else {
+    spine = lastGoodSpineIndex_;
+    page = lastGoodPageNumber_;
+    count = std::max(1, page + 1);
+  }
+  if (total > 0) {
+    if (spine < 0) {
+      spine = 0;
+    }
+    if (spine >= total) {
+      spine = total - 1;
+    }
+  }
+  if (page < 0) {
+    page = 0;
+  }
+
+  if (bookProgress) {
+    BookProgress::Data data;
+    data.spineIndex = static_cast<unsigned int>(spine);
+    data.pageNumber = static_cast<unsigned int>(page);
+    data.chapterPageCount = static_cast<unsigned int>(count);
+    data.lastReadTimestamp = millis();
+    data.progressPercent = 100.0f;
+    bookProgress->save(data);
+  }
+  readingStats_.markBookComplete(*epub);
+  RECENT_BOOKS.addBook(epub->getPath(), epub->getCachePath(), cleanedEpubTitle(*epub), epub->getAuthor(), 1.0f);
+}
+
 void EpubActivity::saveProgress(int spineIndex, int currentPage, int pageCount, const bool saveRecentNow) {
   if (!bookProgress || !epub) {
+    return;
+  }
+  if (dictUi_.isActive() || annUi_.isActive()) {
+    return;
+  }
+
+  const int total = epub->getSpineItemsCount();
+  if (total > 0 && spineIndex >= total) {
+    markBookFinished();
     return;
   }
 
@@ -448,18 +580,24 @@ void EpubActivity::saveProgress(int spineIndex, int currentPage, int pageCount, 
   data.chapterPageCount = pageCount;
   data.lastReadTimestamp = millis();
 
+  float bookProgressValue = 0.0f;
   if (pageCount > 0) {
-    float spineProgress = static_cast<float>(currentPage) / static_cast<float>(pageCount);
-    data.progressPercent = epub->calculateProgress(spineIndex, spineProgress) * 100.0f;
+    const float spineProgress = epubSpineReadFraction(currentPage, pageCount);
+    bookProgressValue = epub->calculateProgress(spineIndex, spineProgress);
+    data.progressPercent = bookProgressValue * 100.0f;
   }
 
   bookProgress->save(data);
 
   if (pageCount > 0) {
-    float spineProgress = static_cast<float>(currentPage) / static_cast<float>(pageCount);
-    float bookProgressValue = epub->calculateProgress(spineIndex, spineProgress);
-    RECENT_BOOKS.addBook(epub->getPath(), epub->getCachePath(), epub->getTitle(), epub->getAuthor(), bookProgressValue,
-                         saveRecentNow);
+    RECENT_BOOKS.addBook(epub->getPath(), epub->getCachePath(), cleanedEpubTitle(*epub), epub->getAuthor(),
+                         bookProgressValue, saveRecentNow);
+  }
+
+  if (isAtEndOfStory()) {
+    markBookFinished();
+  } else if (bookProgressValue < 0.98f) {
+    BOOK_STATE.setFinished(epub->getPath(), false);
   }
 }
 
@@ -570,9 +708,18 @@ void EpubActivity::updateExternalState() {
   APP_STATE.lastRead = "";
   APP_STATE.saveToFile();
 
-  float spineProgress = section ? static_cast<float>(section->currentPage) / section->pageCount : 0;
+  if (!epub) {
+    return;
+  }
+  if (isAtEndOfStory()) {
+    markBookFinished();
+    return;
+  }
+
+  float spineProgress = section ? epubSpineReadFraction(section->currentPage, section->pageCount) : 0;
   float bookProgressValue = epub->calculateProgress(currentSpineIndex, spineProgress);
-  RECENT_BOOKS.addBook(epub->getPath(), epub->getCachePath(), epub->getTitle(), epub->getAuthor(), bookProgressValue);
+  RECENT_BOOKS.addBook(epub->getPath(), epub->getCachePath(), cleanedEpubTitle(*epub), epub->getAuthor(),
+                       bookProgressValue);
 }
 
 /**
@@ -582,10 +729,10 @@ void EpubActivity::fastPath() {
   loadProgress();
   FontManager::ensureReaderLayoutFonts(calculateViewport().fontId, renderer);
   int totalSpineItems = epub->getSpineItemsCount();
-  if (currentSpineIndex >= totalSpineItems) {
-    currentSpineIndex = 0;
-    nextPageNumber = 0;
-    cachedSpineIndex = 0;
+  if (totalSpineItems > 0 && currentSpineIndex >= totalSpineItems) {
+    currentSpineIndex = totalSpineItems - 1;
+    nextPageNumber = static_cast<int>(UINT16_MAX);
+    cachedSpineIndex = currentSpineIndex;
     cachedChapterTotalPageCount = 0;
   }
 
@@ -664,9 +811,9 @@ void EpubActivity::onEnter() {
     }
   }
 
+  initStats();
   updateExternalState();
   loadBookmarks();
-  initStats();
 
   updateRequired = true;
   lastAutoPageTurnTime = millis();
@@ -702,12 +849,9 @@ void EpubActivity::onExit() {
   if (epub) {
     saveBookStats();
 
-    if (section) {
-      float spineProgress = static_cast<float>(section->currentPage) / static_cast<float>(section->pageCount);
-      float bookProgressValue = epub->calculateProgress(currentSpineIndex, spineProgress);
-      RECENT_BOOKS.addBook(epub->getPath(), epub->getCachePath(), epub->getTitle(), epub->getAuthor(),
-                           bookProgressValue);
-
+    if (isAtEndOfStory()) {
+      markBookFinished();
+    } else if (section) {
       saveProgress(currentSpineIndex, section->currentPage, section->pageCount, false);
     }
   }
@@ -865,6 +1009,10 @@ void EpubActivity::loop() {
 
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm) && mappedInput.getHeldTime() < bookmarkHoldMs) {
     pauseReadingStats();
+    if (showingEndOfBook()) {
+      goHome();
+      return;
+    }
     toggleMenuDrawer();
     return;
   }
@@ -1069,8 +1217,7 @@ void EpubActivity::ensureMenuDrawer() {
       menuDrawer->setPercentProvider([this]() -> int {
         float bookProgressPercent = 0.0f;
         if (epub && epub->getBookSize() > 0 && section && section->pageCount > 0) {
-          const float chapterProgress =
-              static_cast<float>(section->currentPage) / static_cast<float>(section->pageCount);
+          const float chapterProgress = epubSpineReadFraction(section->currentPage, section->pageCount);
           bookProgressPercent = epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f;
         }
         int initialPercent = static_cast<int>(bookProgressPercent + 0.5f);
@@ -1493,6 +1640,14 @@ void EpubActivity::jumpToPercent(int percent) {
   section.reset();
 }
 
+bool EpubActivity::showingEndOfBook() const {
+  if (!epub) {
+    return false;
+  }
+  const int total = epub->getSpineItemsCount();
+  return total > 0 && currentSpineIndex >= total;
+}
+
 /**
  * @brief Handles page turning logic
  * @param forward True for forward page turn, false for backward
@@ -1504,7 +1659,15 @@ void EpubActivity::pageTurn(bool forward) {
   }
 
   if (!section) {
-    updateRequired = true;
+    if (showingEndOfBook()) {
+      if (!forward) {
+        currentSpineIndex = lastGoodSpineIndex_;
+        nextPageNumber = lastGoodPageNumber_;
+        updateRequired = true;
+      } else {
+        goHome();
+      }
+    }
     return;
   }
 
@@ -1571,7 +1734,9 @@ void EpubActivity::renderScreen(const bool clearFramebuffer) {
   if (currentSpineIndex >= totalSpine) {
     renderer.clearScreen(0xFF);
     displayBookStats();
-    BOOK_STATE.setFinished(epub->getPath(), true);
+    if (!dictUi_.isActive() && !annUi_.isActive()) {
+      markBookFinished();
+    }
     return;
   }
 
@@ -1594,7 +1759,9 @@ void EpubActivity::renderScreen(const bool clearFramebuffer) {
       if (currentSpineIndex >= totalSpine) {
         renderer.clearScreen(0xFF);
         displayBookStats();
-        BOOK_STATE.setFinished(epub->getPath(), true);
+        if (!dictUi_.isActive() && !annUi_.isActive()) {
+          markBookFinished();
+        }
         return;
       }
       if (wasLayoutReload) {
@@ -2237,5 +2404,6 @@ void EpubActivity::saveBookStats() {
 void EpubActivity::displayBookStats() {
   if (epub) {
     readingStats_.display(renderer, *epub);
+    markBookFinished();
   }
 }

--- a/src/activity/reader/Epub/EpubActivity.h
+++ b/src/activity/reader/Epub/EpubActivity.h
@@ -155,6 +155,9 @@ class EpubActivity final : public ActivityWithSubactivity {
    */
   void pageTurn(bool forward);
 
+  /** True while the post-last-page "End of book" stats screen is showing. */
+  bool showingEndOfBook() const;
+
   /**
    * Renders page contents with margins and status bar.
    *
@@ -260,6 +263,8 @@ class EpubActivity final : public ActivityWithSubactivity {
   void onPercentDrawerSelected(int percent);
   void jumpToPercent(int percent);
 
+  bool isReadingActivity() const override { return true; }
+
   void displayBookTitle();
   void drawLoadingScreen();
   void preloadNextSection();
@@ -348,4 +353,7 @@ class EpubActivity final : public ActivityWithSubactivity {
   void fastPath();
   bool slowPath();
   void displayBookStats();
+  int lastStorySpineIndex() const;
+  bool isAtEndOfStory() const;
+  void markBookFinished();
 };

--- a/src/activity/reader/Epub/EpubReadingStats.cpp
+++ b/src/activity/reader/Epub/EpubReadingStats.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 
 #include "system/Fonts.h"
+#include "state/Statistics.h"
 
 namespace {
 constexpr unsigned long kStatsSaveIntervalMs = 30000;
@@ -78,7 +79,7 @@ void EpubReadingStats::pausePageTimer(const Epub& epub, const Section* section, 
     stats_.lastPageNumber = section->currentPage;
 
     if (section->pageCount > 0) {
-      const float spineProgress = static_cast<float>(section->currentPage) / section->pageCount;
+      const float spineProgress = epubSpineReadFraction(section->currentPage, section->pageCount);
       stats_.progressPercent = epub.calculateProgress(currentSpineIndex, spineProgress) * 100.0f;
     }
 
@@ -115,7 +116,7 @@ void EpubReadingStats::endPageTimer(const Epub& epub, const Section* section, co
     stats_.lastPageNumber = section->currentPage;
 
     if (section->pageCount > 0) {
-      const float spineProgress = static_cast<float>(section->currentPage) / section->pageCount;
+      const float spineProgress = epubSpineReadFraction(section->currentPage, section->pageCount);
       stats_.progressPercent = epub.calculateProgress(currentSpineIndex, spineProgress) * 100.0f;
     }
 
@@ -134,6 +135,32 @@ void EpubReadingStats::endPageTimer(const Epub& epub, const Section* section, co
 }
 
 void EpubReadingStats::addChapterRead() { stats_.totalChaptersRead++; }
+
+void EpubReadingStats::markBookComplete(const Epub& epub) {
+  BookReadingStats onDisk;
+  if (loadBookStats(epub.getCachePath().c_str(), onDisk)) {
+    if (stats_.totalReadingTimeMs < onDisk.totalReadingTimeMs) {
+      stats_ = onDisk;
+    }
+    if (stats_.totalPagesRead < onDisk.totalPagesRead) {
+      stats_.totalPagesRead = onDisk.totalPagesRead;
+    }
+    if (stats_.totalChaptersRead < onDisk.totalChaptersRead) {
+      stats_.totalChaptersRead = onDisk.totalChaptersRead;
+    }
+    if (stats_.avgPageTimeMs == 0) {
+      stats_.avgPageTimeMs = onDisk.avgPageTimeMs;
+    }
+    if (stats_.sessionCount < onDisk.sessionCount) {
+      stats_.sessionCount = onDisk.sessionCount;
+    }
+  } else if (stats_.totalReadingTimeMs == 0 && stats_.totalPagesRead == 0) {
+    // Stats were never loaded this session; do not overwrite a real file with zeros.
+    return;
+  }
+  stats_.progressPercent = 100.0f;
+  save(epub);
+}
 
 std::string EpubReadingStats::chapterTimeLeftString(const Section* section) const {
   if (!section || section->pageCount == 0) {

--- a/src/activity/reader/Epub/EpubReadingStats.h
+++ b/src/activity/reader/Epub/EpubReadingStats.h
@@ -18,6 +18,7 @@ class EpubReadingStats {
   void pausePageTimer(const Epub& epub, const Section* section, int currentSpineIndex);
   void endPageTimer(const Epub& epub, const Section* section, int currentSpineIndex);
   void addChapterRead();
+  void markBookComplete(const Epub& epub);
   void save(const Epub& epub);
   void display(GfxRenderer& renderer, const Epub& epub) const;
 

--- a/src/activity/reader/Epub/StatusBar.cpp
+++ b/src/activity/reader/Epub/StatusBar.cpp
@@ -459,6 +459,6 @@ std::string StatusBar::getChapterTitle(int currentSpineIndex) const {
  */
 float StatusBar::calculateBookProgress(const Section* section, int currentSpineIndex) const {
   if (!section || section->pageCount == 0) return 0;
-  float spineProgress = static_cast<float>(section->currentPage) / section->pageCount;
+  const float spineProgress = epubSpineReadFraction(section->currentPage, section->pageCount);
   return m_epub.calculateProgress(currentSpineIndex, spineProgress) * 100;
 }

--- a/src/state/BookProgress.cpp
+++ b/src/state/BookProgress.cpp
@@ -7,6 +7,7 @@
 
 #include <SDCardManager.h>
 
+#include <cstdint>
 #include <cstring>
 
 BookProgress::BookProgress(const std::string& cachePath) : filePath(cachePath + "/progress.bin") {}
@@ -57,11 +58,13 @@ bool BookProgress::validate(const Data& data, int totalSpines) const {
 }
 
 void BookProgress::sanitize(Data& data, int totalSpines) const {
-  if (totalSpines > 0) {
-    if (data.spineIndex >= totalSpines) {
-      data.spineIndex = 0;
-      data.pageNumber = 0;
-      data.chapterPageCount = 0;
-    }
+  if (totalSpines <= 0) {
+    return;
+  }
+  // Spine == total is the end-of-book sentinel. Clamp to the last real page instead of
+  // wiping back to chapter 0, which made finished books reopen at the start.
+  if (data.spineIndex >= static_cast<unsigned int>(totalSpines)) {
+    data.spineIndex = static_cast<unsigned int>(totalSpines - 1);
+    data.pageNumber = 0xFFFFu;
   }
 }


### PR DESCRIPTION
Finished books were landing at ~99% and often reopening at chapter 0.

Progress used `currentPage / pageCount`, so the last page of a spine is `(n-1)/n`, never 100%. `BookProgress::sanitize()` also treated `spineIndex == total` (the end-of-book sentinel) as corrupt and reset to spine 0.

What changed:
- `epubSpineReadFraction()` — last page of a spine is 1.0. Status bar and reading stats use it.
- `lastStorySpineIndex()` — last TOC entry that is not back matter, but only if that spine is in the last quarter of the book (avoids marking a mid-book “Credits” chapter as the end).
- `markBookFinished()` — sets `BOOK_STATE` finished, writes 100% stats, keeps a real page instead of wiping progress.
- Recents Grid/List/Flow show **Finished** when progress ≥ 99.5% or `isFinished` is set. Flow side covers wrap with the selector.

Overlap with #122: this also adds `Activity::isReadingActivity()` / the EPUB override. Harmless if both land; git should merge it.

## Test on device
- Page past the last story page → End of book stats, recents say Finished not 99%
- Reopen that book → last page, not chapter 1
- A book whose TOC has “Acknowledgements” after the story still finishes on the last real chapter
- Grid, List, and Flow all agree on Finished
- Flow: wrap from last recent to first; side covers follow