### PR TITLE
Share highlight and dictionary word navigation

### DIFF
--- a/src/activity/reader/Epub/EpubAnnotationUi.cpp
+++ b/src/activity/reader/Epub/EpubAnnotationUi.cpp
@@ -12,6 +12,7 @@
 #include <new>
 
 #include "EpubActivity.h"
+#include "WordOverlayNav.h"
 #include "system/FontManager.h"
 #include "system/Fonts.h"
 #include "system/MappedInputManager.h"
@@ -20,10 +21,6 @@ namespace {
 
 constexpr unsigned long kChordHoldMs = 600;
 constexpr int kHighlightLatticeStepPx = 2;
-/** ADC/button bounce can deliver two wasPressed edges ~ms apart; loop has no delay — suppress 2nd edge. */
-constexpr unsigned long kNavEdgeDebounceMs = 130;
-constexpr unsigned long kNavRepeatInitialMs = 700;
-constexpr unsigned long kNavRepeatIntervalMs = 95;
 
 }  // namespace
 
@@ -80,15 +77,6 @@ void EpubAnnotationUi::tryChordEnter(EpubActivity& act) {
     chordStartMs_ = 0;
     chordConsumed_ = false;
   }
-}
-
-bool EpubAnnotationUi::isDuplicateNavEdge(const int dir, const unsigned long now) {
-  if (annLastNavEdgeDir_ == dir && (now - annLastNavEdgeMs_) < kNavEdgeDebounceMs) {
-    return true;
-  }
-  annLastNavEdgeMs_ = now;
-  annLastNavEdgeDir_ = dir;
-  return false;
 }
 
 bool EpubAnnotationUi::hasSaveableContent() const {
@@ -210,82 +198,17 @@ void EpubAnnotationUi::exit(EpubActivity& act) {
 }
 
 bool EpubAnnotationUi::tryNavigationHoldRepeat(EpubActivity& act) {
-  using Btn = MappedInputManager::Button;
-  const MappedInputManager& m = act.mappedInput;
-  const unsigned long now = millis();
-
-  // One edge = one move. Holding the same direction starts repeat only after a long enough delay
-  // that a normal click cannot jump two words/lines.
-  if (m.wasPressed(Btn::Left)) {
-    if (isDuplicateNavEdge(0, now)) {
-      return true;
-    }
-    moveFocusWord(-1);
-    annNavRepeatDir_ = 0;
-    annNavRepeatNextMs_ = now + kNavRepeatInitialMs;
+  WordOverlayNav::EdgeState edge{annLastNavEdgeMs_, annLastNavEdgeDir_};
+  const int nav = WordOverlayNav::handleDpad(
+      act.mappedInput, edge, annNavRepeatDir_, annNavRepeatNextMs_, millis(),
+      [this](const int delta) { moveFocusWord(delta); },
+      [this](const int delta, const bool wrap) { moveFocusLine(delta, wrap); });
+  annLastNavEdgeMs_ = edge.lastMs;
+  annLastNavEdgeDir_ = edge.lastDir;
+  if (nav == 2) {
     act.updateRequired = true;
-    return true;
   }
-  if (m.wasPressed(Btn::Right)) {
-    if (isDuplicateNavEdge(1, now)) {
-      return true;
-    }
-    moveFocusWord(1);
-    annNavRepeatDir_ = 1;
-    annNavRepeatNextMs_ = now + kNavRepeatInitialMs;
-    act.updateRequired = true;
-    return true;
-  }
-  if (m.wasPressed(Btn::Up)) {
-    if (isDuplicateNavEdge(2, now)) {
-      return true;
-    }
-    moveFocusLine(-1);
-    annNavRepeatDir_ = 2;
-    annNavRepeatNextMs_ = now + kNavRepeatInitialMs;
-    act.updateRequired = true;
-    return true;
-  }
-  if (m.wasPressed(Btn::Down)) {
-    if (isDuplicateNavEdge(3, now)) {
-      return true;
-    }
-    moveFocusLine(1);
-    annNavRepeatDir_ = 3;
-    annNavRepeatNextMs_ = now + kNavRepeatInitialMs;
-    act.updateRequired = true;
-    return true;
-  }
-  const bool leftHeld = m.isPressed(Btn::Left);
-  const bool rightHeld = m.isPressed(Btn::Right);
-  const bool upHeld = m.isPressed(Btn::Up);
-  const bool downHeld = m.isPressed(Btn::Down);
-  if (!leftHeld && !rightHeld && !upHeld && !downHeld) {
-    annNavRepeatDir_ = -1;
-    return false;
-  }
-  if (annNavRepeatDir_ < 0 || now < annNavRepeatNextMs_) {
-    return false;
-  }
-  if (annNavRepeatDir_ == 0 && leftHeld) {
-    moveFocusWord(-1);
-  } else if (annNavRepeatDir_ == 1 && rightHeld) {
-    moveFocusWord(1);
-  } else if (annNavRepeatDir_ == 2 && upHeld) {
-    // Auto-repeat covers 2 lines/tick (vs. 1 for the initial press) - holding Up/Down would
-    // otherwise take forever to cross a full page at kNavRepeatIntervalMs.
-    moveFocusLine(-1);
-    moveFocusLine(-1);
-  } else if (annNavRepeatDir_ == 3 && downHeld) {
-    moveFocusLine(1);
-    moveFocusLine(1);
-  } else {
-    annNavRepeatDir_ = -1;
-    return false;
-  }
-  annNavRepeatNextMs_ = now + kNavRepeatIntervalMs;
-  act.updateRequired = true;
-  return true;
+  return nav != 0;
 }
 
 std::string EpubAnnotationUi::extractRangeText(const size_t anchorFlat, const size_t focusFlat) const {
@@ -558,46 +481,11 @@ void EpubAnnotationUi::drawUiOverlay(EpubActivity& act) {
 }
 
 void EpubAnnotationUi::moveFocusWord(const int delta) {
-  if (words_.empty()) {
-    return;
-  }
-  if (delta < 0) {
-    if (focus_ > 0) {
-      focus_--;
-    }
-    return;
-  }
-  if (focus_ + 1 < words_.size()) {
-    focus_++;
-  }
+  WordOverlayNav::moveFocusWord(words_, focus_, delta);
 }
 
-void EpubAnnotationUi::moveFocusLine(const int delta) {
-  if (lineFirst_.empty() || words_.empty()) {
-    return;
-  }
-  size_t lineIdx = 0;
-  for (size_t i = 0; i < lineFirst_.size(); ++i) {
-    const size_t start = lineFirst_[i];
-    const size_t end = (i + 1 < lineFirst_.size()) ? lineFirst_[i + 1] : words_.size();
-    if (focus_ >= start && focus_ < end) {
-      lineIdx = i;
-      break;
-    }
-  }
-  if (delta < 0) {
-    if (lineIdx == 0) {
-      return;
-    }
-    lineIdx--;
-    focus_ = lineFirst_[lineIdx];
-  } else {
-    if (lineIdx + 1 >= lineFirst_.size()) {
-      return;
-    }
-    lineIdx++;
-    focus_ = lineFirst_[lineIdx];
-  }
+void EpubAnnotationUi::moveFocusLine(const int delta, const bool wrap) {
+  WordOverlayNav::moveFocusLine(words_, lineFirst_, focus_, delta, wrap);
 }
 
 void EpubAnnotationUi::handleInput(EpubActivity& act) {

--- a/src/activity/reader/Epub/EpubAnnotationUi.h
+++ b/src/activity/reader/Epub/EpubAnnotationUi.h
@@ -75,13 +75,10 @@ class EpubAnnotationUi {
   void drawHighlights(EpubActivity& act);
 
   void moveFocusWord(int delta);
-  void moveFocusLine(int delta);
+  void moveFocusLine(int delta, bool wrap);
   bool tryNavigationHoldRepeat(EpubActivity& act);
 
   void captureFramebuffer(EpubActivity& act);
-
-  /** @param dir 0=L,1=R,2=U,3=D */
-  bool isDuplicateNavEdge(int dir, unsigned long now);
 
   bool hasSaveableContent() const;
   void resetSelectionToStart(EpubActivity& act);
@@ -112,10 +109,8 @@ class EpubAnnotationUi {
   bool selectingStarted_ = false;
   /** Completed ranges while browsing between Start/Stop cycles (same page). */
   std::vector<std::pair<size_t, size_t>> pendingSpans_;
-  /** Suppress duplicate wasPressed edges (ADC bounce) for the same direction. */
   unsigned long annLastNavEdgeMs_ = 0;
   int annLastNavEdgeDir_ = -1;  // 0 L, 1 R, 2 U, 3 D; -1 = none
-  /** D-pad hold-repeat: -1 = none; else same encoding as annLastNavEdgeDir_. */
   int annNavRepeatDir_ = -1;
   unsigned long annNavRepeatNextMs_ = 0;
 

--- a/src/activity/reader/Epub/EpubDictionaryUi.cpp
+++ b/src/activity/reader/Epub/EpubDictionaryUi.cpp
@@ -15,6 +15,7 @@
 #include <esp_task_wdt.h>
 
 #include "EpubActivity.h"
+#include "WordOverlayNav.h"
 #include "dictionary/DictionaryDefinitionLayout.h"
 #include "dictionary/DictionaryRegistry.h"
 #include "state/SavedDictionaryWords.h"
@@ -28,9 +29,6 @@ namespace {
 
 constexpr unsigned long kChordHoldMs = 600;
 constexpr int kHighlightLatticeStepPx = 2;
-constexpr unsigned long kNavEdgeDebounceMs = 130;
-constexpr unsigned long kNavRepeatInitialMs = 700;
-constexpr unsigned long kNavRepeatIntervalMs = 95;
 
 // Shared between performLookup() (to lay out definitionLines_ once, at the width it'll actually be
 // rendered at) and drawDefinitionPanel() (to size/draw the panel itself).
@@ -100,15 +98,6 @@ void EpubDictionaryUi::tryChordEnter(EpubActivity& act) {
     chordStartMs_ = 0;
     chordConsumed_ = false;
   }
-}
-
-bool EpubDictionaryUi::isDuplicateNavEdge(const int dir, const unsigned long now) {
-  if (lastNavEdgeDir_ == dir && (now - lastNavEdgeMs_) < kNavEdgeDebounceMs) {
-    return true;
-  }
-  lastNavEdgeMs_ = now;
-  lastNavEdgeDir_ = dir;
-  return false;
 }
 
 void EpubDictionaryUi::prepareWordGeometry(EpubActivity& act) {
@@ -497,80 +486,17 @@ void EpubDictionaryUi::performLookup(EpubActivity& act) {
 }
 
 bool EpubDictionaryUi::tryNavigationHoldRepeat(EpubActivity& act) {
-  using Btn = MappedInputManager::Button;
-  const MappedInputManager& m = act.mappedInput;
-  const unsigned long now = millis();
-
-  if (m.wasPressed(Btn::Left)) {
-    if (isDuplicateNavEdge(0, now)) {
-      return true;
-    }
-    moveFocusWord(-1);
-    navRepeatDir_ = 0;
-    navRepeatNextMs_ = now + kNavRepeatInitialMs;
+  WordOverlayNav::EdgeState edge{lastNavEdgeMs_, lastNavEdgeDir_};
+  const int nav = WordOverlayNav::handleDpad(
+      act.mappedInput, edge, navRepeatDir_, navRepeatNextMs_, millis(),
+      [this](const int delta) { moveFocusWord(delta); },
+      [this](const int delta, const bool wrap) { moveFocusLine(delta, wrap); });
+  lastNavEdgeMs_ = edge.lastMs;
+  lastNavEdgeDir_ = edge.lastDir;
+  if (nav == 2) {
     act.updateRequired = true;
-    return true;
   }
-  if (m.wasPressed(Btn::Right)) {
-    if (isDuplicateNavEdge(1, now)) {
-      return true;
-    }
-    moveFocusWord(1);
-    navRepeatDir_ = 1;
-    navRepeatNextMs_ = now + kNavRepeatInitialMs;
-    act.updateRequired = true;
-    return true;
-  }
-  if (m.wasPressed(Btn::Up)) {
-    if (isDuplicateNavEdge(2, now)) {
-      return true;
-    }
-    moveFocusLine(-1);
-    navRepeatDir_ = 2;
-    navRepeatNextMs_ = now + kNavRepeatInitialMs;
-    act.updateRequired = true;
-    return true;
-  }
-  if (m.wasPressed(Btn::Down)) {
-    if (isDuplicateNavEdge(3, now)) {
-      return true;
-    }
-    moveFocusLine(1);
-    navRepeatDir_ = 3;
-    navRepeatNextMs_ = now + kNavRepeatInitialMs;
-    act.updateRequired = true;
-    return true;
-  }
-  const bool leftHeld = m.isPressed(Btn::Left);
-  const bool rightHeld = m.isPressed(Btn::Right);
-  const bool upHeld = m.isPressed(Btn::Up);
-  const bool downHeld = m.isPressed(Btn::Down);
-  if (!leftHeld && !rightHeld && !upHeld && !downHeld) {
-    navRepeatDir_ = -1;
-    return false;
-  }
-  if (navRepeatDir_ < 0 || now < navRepeatNextMs_) {
-    return false;
-  }
-  if (navRepeatDir_ == 0 && leftHeld) {
-    moveFocusWord(-1);
-  } else if (navRepeatDir_ == 1 && rightHeld) {
-    moveFocusWord(1);
-  } else if (navRepeatDir_ == 2 && upHeld) {
-    // Auto-repeat covers 2 lines/tick (vs. 1 for the initial press) - holding Up/Down would
-    // otherwise take forever to cross a full page at kNavRepeatIntervalMs.
-    moveFocusLine(-1);
-    moveFocusLine(-1);
-  } else if (navRepeatDir_ == 3 && downHeld) {
-    moveFocusLine(1);
-    moveFocusLine(1);
-  } else {
-    navRepeatDir_ = -1;
-    return false;
-  }
-  navRepeatNextMs_ = now + kNavRepeatIntervalMs;
-  act.updateRequired = true;
-  return true;
+  return nav != 0;
 }
 
 /** Saves lookedUpWord_ plus the definition currently on screen. Idempotent — a repeat Confirm on an
@@ -590,46 +516,11 @@ void EpubDictionaryUi::saveCurrentWord(EpubActivity& act) {
 }
 
 void EpubDictionaryUi::moveFocusWord(const int delta) {
-  if (words_.empty()) {
-    return;
-  }
-  if (delta < 0) {
-    if (focus_ > 0) {
-      focus_--;
-    }
-    return;
-  }
-  if (focus_ + 1 < words_.size()) {
-    focus_++;
-  }
+  WordOverlayNav::moveFocusWord(words_, focus_, delta);
 }
 
-void EpubDictionaryUi::moveFocusLine(const int delta) {
-  if (lineFirst_.empty() || words_.empty()) {
-    return;
-  }
-  size_t lineIdx = 0;
-  for (size_t i = 0; i < lineFirst_.size(); ++i) {
-    const size_t start = lineFirst_[i];
-    const size_t end = (i + 1 < lineFirst_.size()) ? lineFirst_[i + 1] : words_.size();
-    if (focus_ >= start && focus_ < end) {
-      lineIdx = i;
-      break;
-    }
-  }
-  if (delta < 0) {
-    if (lineIdx == 0) {
-      return;
-    }
-    lineIdx--;
-    focus_ = lineFirst_[lineIdx];
-  } else {
-    if (lineIdx + 1 >= lineFirst_.size()) {
-      return;
-    }
-    lineIdx++;
-    focus_ = lineFirst_[lineIdx];
-  }
+void EpubDictionaryUi::moveFocusLine(const int delta, const bool wrap) {
+  WordOverlayNav::moveFocusLine(words_, lineFirst_, focus_, delta, wrap);
 }
 
 void EpubDictionaryUi::handleInput(EpubActivity& act) {

--- a/src/activity/reader/Epub/EpubDictionaryUi.h
+++ b/src/activity/reader/Epub/EpubDictionaryUi.h
@@ -36,9 +36,8 @@ class EpubDictionaryUi {
   void prepareWordGeometry(EpubActivity& act);
   void captureFramebuffer(EpubActivity& act);
   void moveFocusWord(int delta);
-  void moveFocusLine(int delta);
+  void moveFocusLine(int delta, bool wrap);
   bool tryNavigationHoldRepeat(EpubActivity& act);
-  bool isDuplicateNavEdge(int dir, unsigned long now);
   void drawFocusHighlight(EpubActivity& act);
   void drawDefinitionPanel(EpubActivity& act);
   void performLookup(EpubActivity& act);

--- a/src/activity/reader/Epub/WordOverlayNav.h
+++ b/src/activity/reader/Epub/WordOverlayNav.h
@@ -1,0 +1,203 @@
+#pragma once
+
+/**
+ * Shared D-pad movement for highlight + dictionary word pickers.
+ *
+ * Up on the first line jumps to the last word on the page (so the bottom is one press away).
+ * Down on the last line jumps to the first word. A second press of the same button within a short
+ * window skips several words/lines. Hold-repeat does not wrap, so a held Down stops at the bottom.
+ */
+
+#include <Epub/PageWordIndex.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdlib>
+#include <vector>
+
+#include "system/MappedInputManager.h"
+
+namespace WordOverlayNav {
+
+constexpr unsigned long kBounceMs = 50;
+constexpr unsigned long kDoubleTapMs = 340;
+constexpr int kDoubleTapStride = 3;
+constexpr unsigned long kRepeatInitialMs = 700;
+constexpr unsigned long kRepeatIntervalMs = 95;
+constexpr int kRepeatLineStride = 3;
+constexpr int kRepeatWordStride = 3;
+
+struct EdgeState {
+  unsigned long lastMs = 0;
+  int lastDir = -1;
+  EdgeState() = default;
+  EdgeState(unsigned long ms, int dir) : lastMs(ms), lastDir(dir) {}
+};
+
+inline bool isBounce(EdgeState& state, const int dir, const unsigned long now) {
+  if (state.lastDir == dir && (now - state.lastMs) < kBounceMs) {
+    state.lastMs = now;
+    return true;
+  }
+  return false;
+}
+
+inline int stepsForPress(EdgeState& state, const int dir, const unsigned long now) {
+  const int steps =
+      (state.lastDir == dir && (now - state.lastMs) < kDoubleTapMs) ? kDoubleTapStride : 1;
+  state.lastMs = now;
+  state.lastDir = dir;
+  return steps;
+}
+
+inline void moveFocusWord(const std::vector<PageWordHit>& words, size_t& focus, const int delta) {
+  if (words.empty() || delta == 0) {
+    return;
+  }
+  if (delta > 0) {
+    const size_t room = words.size() - 1 - focus;
+    focus += std::min(static_cast<size_t>(delta), room);
+    return;
+  }
+  const size_t back = static_cast<size_t>(-delta);
+  focus = (back >= focus) ? 0 : focus - back;
+}
+
+inline size_t lineIndexForFocus(const std::vector<size_t>& lineFirst, const size_t wordCount, const size_t focus) {
+  if (lineFirst.empty()) {
+    return 0;
+  }
+  size_t lineIdx = 0;
+  for (size_t i = 0; i < lineFirst.size(); ++i) {
+    const size_t start = lineFirst[i];
+    const size_t end = (i + 1 < lineFirst.size()) ? lineFirst[i + 1] : wordCount;
+    if (focus >= start && focus < end) {
+      lineIdx = i;
+      break;
+    }
+  }
+  return lineIdx;
+}
+
+inline size_t wordOnLineNearestX(const std::vector<PageWordHit>& words, const std::vector<size_t>& lineFirst,
+                                 const size_t lineIdx, const int targetX) {
+  const size_t start = lineFirst[lineIdx];
+  const size_t end = (lineIdx + 1 < lineFirst.size()) ? lineFirst[lineIdx + 1] : words.size();
+  size_t best = start;
+  int bestDist = 0x7fffffff;
+  for (size_t i = start; i < end; ++i) {
+    const int cx = words[i].screenX + words[i].screenW / 2;
+    const int dist = std::abs(cx - targetX);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = i;
+    }
+  }
+  return best;
+}
+
+/** @param wrap If true, Up on the first line goes to the last word and Down on the last line goes
+ *  to the first word. Remaining steps after a wrap are ignored so that jump lands on the end. */
+inline void moveFocusLine(const std::vector<PageWordHit>& words, const std::vector<size_t>& lineFirst, size_t& focus,
+                          const int delta, const bool wrap) {
+  if (words.empty() || lineFirst.empty() || delta == 0) {
+    return;
+  }
+  size_t lineIdx = lineIndexForFocus(lineFirst, words.size(), focus);
+  const int targetX = words[focus].screenX + words[focus].screenW / 2;
+  const int sign = delta > 0 ? 1 : -1;
+  int remaining = delta > 0 ? delta : -delta;
+  while (remaining > 0) {
+    if (sign < 0) {
+      if (lineIdx == 0) {
+        if (wrap) {
+          focus = words.size() - 1;
+        }
+        return;
+      }
+      --lineIdx;
+    } else {
+      if (lineIdx + 1 >= lineFirst.size()) {
+        if (wrap) {
+          focus = 0;
+        }
+        return;
+      }
+      ++lineIdx;
+    }
+    --remaining;
+  }
+  focus = wordOnLineNearestX(words, lineFirst, lineIdx, targetX);
+}
+
+/** @return 0 none, 1 bounce consumed (no move), 2 moved */
+template <typename MoveWord, typename MoveLine>
+int handleDpad(const MappedInputManager& mapped, EdgeState& edge, int& repeatDir, unsigned long& repeatNextMs,
+               const unsigned long now, MoveWord&& moveWord, MoveLine&& moveLine) {
+  using Btn = MappedInputManager::Button;
+
+  if (mapped.wasPressed(Btn::Left)) {
+    if (isBounce(edge, 0, now)) {
+      return 1;
+    }
+    moveWord(-stepsForPress(edge, 0, now));
+    repeatDir = 0;
+    repeatNextMs = now + kRepeatInitialMs;
+    return 2;
+  }
+  if (mapped.wasPressed(Btn::Right)) {
+    if (isBounce(edge, 1, now)) {
+      return 1;
+    }
+    moveWord(stepsForPress(edge, 1, now));
+    repeatDir = 1;
+    repeatNextMs = now + kRepeatInitialMs;
+    return 2;
+  }
+  if (mapped.wasPressed(Btn::Up)) {
+    if (isBounce(edge, 2, now)) {
+      return 1;
+    }
+    moveLine(-stepsForPress(edge, 2, now), true);
+    repeatDir = 2;
+    repeatNextMs = now + kRepeatInitialMs;
+    return 2;
+  }
+  if (mapped.wasPressed(Btn::Down)) {
+    if (isBounce(edge, 3, now)) {
+      return 1;
+    }
+    moveLine(stepsForPress(edge, 3, now), true);
+    repeatDir = 3;
+    repeatNextMs = now + kRepeatInitialMs;
+    return 2;
+  }
+
+  const bool leftHeld = mapped.isPressed(Btn::Left);
+  const bool rightHeld = mapped.isPressed(Btn::Right);
+  const bool upHeld = mapped.isPressed(Btn::Up);
+  const bool downHeld = mapped.isPressed(Btn::Down);
+  if (!leftHeld && !rightHeld && !upHeld && !downHeld) {
+    repeatDir = -1;
+    return 0;
+  }
+  if (repeatDir < 0 || now < repeatNextMs) {
+    return 0;
+  }
+  if (repeatDir == 0 && leftHeld) {
+    moveWord(-kRepeatWordStride);
+  } else if (repeatDir == 1 && rightHeld) {
+    moveWord(kRepeatWordStride);
+  } else if (repeatDir == 2 && upHeld) {
+    moveLine(-kRepeatLineStride, false);
+  } else if (repeatDir == 3 && downHeld) {
+    moveLine(kRepeatLineStride, false);
+  } else {
+    repeatDir = -1;
+    return 0;
+  }
+  repeatNextMs = now + kRepeatIntervalMs;
+  return 2;
+}
+
+}  // namespace WordOverlayNav


### PR DESCRIPTION
Highlight and dictionary each had their own D-pad loop (bounce debounce, hold-repeat, line walking). They drifted: dictionary wrapping, highlight not wrapping, accidental double-steps from ADC bounce, hold-repeat that was painful on a full page.

`WordOverlayNav.h` is the one implementation both overlays call.

Behavior:
- Left/Right = word, Up/Down = line (keeps X so you stay in the same column)
- Tap: one step. Second tap of the same button within 340ms jumps 3 words/lines
- Up on the first line goes to the last word on the page (bottom is one press away). Down on the last line goes to the first. **Hold-repeat does not wrap**, so a held Down stops at the bottom
- Bounce window is 50ms

If heap is too low to layout HTML (`maxAlloc ≤ 16KB`), the definition panel used to show the headword and an empty body even after a successful lookup. It now falls back to a truncated plain-text line.

No firmware dict-index changes here; that is #124.

## Test on device
- Dictionary chord, walk a page with Left/Right and Up/Down
- Up from the top line → last word. Down from the bottom line → first word
- Hold Down from mid-page → stops at the last line (does not wrap)
- Double-tap Down → skips a few lines
- Same in highlight mode (Down+Right)
- Lookup still shows definition text on a heavy page / low heap