### PR TITLE
Look up words in the language of the sentence

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -181,6 +181,23 @@ The role of the volume (side) buttons can be swapped in **[Settings](#35-setting
 
 If the **Short Power Button Click** setting is set to "Page Turn", you can also turn to the next page by briefly pressing the Power button.
 
+### Dictionary
+
+Hold **Down + Left** while reading, then Confirm to look up the highlighted word. On a definition, Confirm saves the word; Left/Right switches dictionary if the guessed language is wrong.
+
+Put StarDict folders in `/dictionaries` on the SD card, **one folder per language**. Each folder needs uncompressed `.ifo`, `.idx`, and `.dict` files. Inx does **not** read `.dict.dz` — decompress that first (`dictunzip file.dict.dz`, or `gunzip -c file.dict.dz > file.dict`).
+
+Good sources:
+
+- [FreeDict StarDict downloads](https://freedict.org/downloads/) — pick **StarDict**, then **Dutch–English**, **English–Dutch**, **French–English**, **English–French**.
+- [Hu Zheng’s StarDict archive](http://download.huzheng.org/) — older packs, including English defining dictionaries.
+
+Extract each archive so you have one folder per language, copy those folders into `/dictionaries`, then **Sync → Choose dictionaries**. Left/Right assigns Dutch / English / French / Latin if the folder name was not enough. Confirm sets the fallback dictionary.
+
+Lookups use the surrounding sentence, not only the book's language, so a French, Dutch, or Latin stretch inside an English book can still hit the right dictionary. Inflected forms that only say "past participle of …" are skipped; the lemma is looked up instead, and if that translation dictionary still has no real gloss the same-language defining dictionary is tried (English→Dutch miss → English). Left/Right still cycles every installed folder.
+
+Saved words live under Home → Dictionary. From a computer on the device hotspot, open `/api/dictionary-words.csv` to download an Anki-ready file (word, definition, language).
+
 ### Chapter Navigation
 * **Next Chapter:** Press and **hold** the **Right** (or **Volume Down**) button briefly, then release.
 * **Previous Chapter:** Press and **hold** the **Left** (or **Volume Up**) button briefly, then release.

--- a/src/activity/page/SyncActivity.cpp
+++ b/src/activity/page/SyncActivity.cpp
@@ -22,7 +22,7 @@ namespace {
 constexpr int MENU_ITEM_COUNT = 9;
 const char* MENU_ITEMS[MENU_ITEM_COUNT] = {"Manage via wifi",   "Connect to calibre", "Create hotspot",
                                            "OPDS Browser",      "Backup and restore", "KOReader Sync",
-                                           "Check for updates", "Choose dictionary",  "Device"};
+                                           "Check for updates", "Choose dictionaries",  "Device"};
 constexpr int LIST_ITEM_HEIGHT = UiTheme::DRAWER_LIST_ITEM_HEIGHT;
 }  // namespace
 

--- a/src/activity/reader/Epub/EpubDictionaryUi.cpp
+++ b/src/activity/reader/Epub/EpubDictionaryUi.cpp
@@ -1,5 +1,6 @@
 #include "EpubDictionaryUi.h"
 
+#include <EpdFontFamily.h>
 #include <Epub/Page.h>
 #include <Epub/PageWordIndex.h>
 #include <GfxRenderer.h>
@@ -10,11 +11,17 @@
 #include <cstring>
 #include <new>
 
+#include <Arduino.h>
+#include <esp_task_wdt.h>
+
 #include "EpubActivity.h"
+#include "WordOverlayNav.h"
 #include "dictionary/DictionaryDefinitionLayout.h"
+#include "dictionary/DictionaryRegistry.h"
 #include "state/SavedDictionaryWords.h"
 #include "state/ReaderSetting.h"
 #include "state/SystemSetting.h"
+#include "system/FontManager.h"
 #include "system/Fonts.h"
 #include "system/MappedInputManager.h"
 
@@ -22,26 +29,33 @@ namespace {
 
 constexpr unsigned long kChordHoldMs = 600;
 constexpr int kHighlightLatticeStepPx = 2;
-constexpr unsigned long kNavEdgeDebounceMs = 130;
-constexpr unsigned long kNavRepeatInitialMs = 700;
-constexpr unsigned long kNavRepeatIntervalMs = 95;
 
 // Shared between performLookup() (to lay out definitionLines_ once, at the width it'll actually be
 // rendered at) and drawDefinitionPanel() (to size/draw the panel itself).
 constexpr int kDefinitionPanelMargin = 16;
 constexpr int kDefinitionPanelPad = 20;
 
-std::string stripSurroundingPunctuation(const std::string& s) {
-  size_t start = 0;
-  size_t end = s.size();
-  auto keep = [](unsigned char c) { return std::isalnum(c) || c == '\'' || c == '-'; };
-  while (start < end && !keep(static_cast<unsigned char>(s[start]))) {
-    ++start;
+std::string stripHtmlToPlain(const std::string& html) {
+  std::string out;
+  out.reserve(html.size());
+  bool inTag = false;
+  for (unsigned char c : html) {
+    if (c == '<') {
+      inTag = true;
+      continue;
+    }
+    if (c == '>') {
+      inTag = false;
+      if (!out.empty() && out.back() != ' ') {
+        out.push_back(' ');
+      }
+      continue;
+    }
+    if (!inTag) {
+      out.push_back(static_cast<char>(c));
+    }
   }
-  while (end > start && !keep(static_cast<unsigned char>(s[end - 1]))) {
-    --end;
-  }
-  return s.substr(start, end - start);
+  return out;
 }
 
 }  // namespace
@@ -59,6 +73,11 @@ void EpubDictionaryUi::tryChordEnter(EpubActivity& act) {
     if (chordStartMs_ == 0) {
       chordStartMs_ = millis();
     }
+    // Start opening the dictionary while the chord is still held so Confirm is a RAM/SD seek,
+    // not a multi-second .idx scan. Warm open() is a no-op.
+    if (millis() - chordStartMs_ >= 80 && ESP.getFreeHeap() > 80000) {
+      ensureDictionaryOpen(act);
+    }
     if (!chordConsumed_ && millis() - chordStartMs_ >= kChordHoldMs) {
       enter(act);
       chordConsumed_ = true;
@@ -67,15 +86,6 @@ void EpubDictionaryUi::tryChordEnter(EpubActivity& act) {
     chordStartMs_ = 0;
     chordConsumed_ = false;
   }
-}
-
-bool EpubDictionaryUi::isDuplicateNavEdge(const int dir, const unsigned long now) {
-  if (lastNavEdgeDir_ == dir && (now - lastNavEdgeMs_) < kNavEdgeDebounceMs) {
-    return true;
-  }
-  lastNavEdgeMs_ = now;
-  lastNavEdgeDir_ = dir;
-  return false;
 }
 
 void EpubDictionaryUi::prepareWordGeometry(EpubActivity& act) {
@@ -214,209 +224,274 @@ void EpubDictionaryUi::releaseDefinitionMemory() {
   definitionScrollable_ = false;
 }
 
-void EpubDictionaryUi::ensureDictionaryOpen() {
-  if (READER_SETTINGS.dictionaryFolder[0] == '\0') {
-    Serial.printf("[%lu] [DICT] ensureDictionaryOpen: READER_SETTINGS.dictionaryFolder is empty\n", millis());
+void EpubDictionaryUi::openFolder(const std::string& folderName) {
+  if (folderName.empty()) {
     return;
   }
-  const std::string folder = std::string("/dictionaries/") + READER_SETTINGS.dictionaryFolder;
-  // open() is a no-op when the same folder is already warm - safe to call every lookup.
+  const std::string folder = std::string(DictionaryRegistry::kDictionariesRoot) + "/" + folderName;
   if (dict_.isOpen() && dict_.folderPath() == folder) {
     return;
   }
-  const bool opened = dict_.open(folder);
-  Serial.printf("[%lu] [DICT] ensureDictionaryOpen: open('%s') -> %d\n", millis(), folder.c_str(), opened ? 1 : 0);
+  (void)dict_.open(folder);
+}
+
+void EpubDictionaryUi::ensureDictionaryOpen(EpubActivity& act) {
+  preferredFolder_ = resolvePreferredFolder(act);
+  if (preferredFolder_.empty()) {
+    Serial.printf("[%lu] [DICT] ensureDictionaryOpen: no dictionary folders found\n", millis());
+    return;
+  }
+  openFolder(preferredFolder_);
+  Serial.printf("[%lu] [DICT] ensureDictionaryOpen: preferred='%s' open=%d session='%s'\n", millis(),
+                preferredFolder_.c_str(), dict_.isOpen() ? 1 : 0, sessionFolder_.c_str());
+}
+
+std::string EpubDictionaryUi::resolvePreferredFolder(EpubActivity& act) {
+  std::string detected;
+  if (!words_.empty() && focus_ < words_.size()) {
+    const size_t start = focus_ > 6 ? focus_ - 6 : 0;
+    const size_t end = std::min(words_.size(), focus_ + 7);
+    std::vector<std::string> window;
+    window.reserve(end - start);
+    for (size_t i = start; i < end; ++i) {
+      window.push_back(StarDictLookup::stripSurroundingPunctuation(words_[i].text));
+    }
+    detected = DictionaryRegistry::detectLanguage(window, focus_ - start);
+  }
+  std::string bookLang;
+  if (act.epub) {
+    bookLang = act.epub->getLanguage();
+  }
+  return DictionaryRegistry::folderForLookup(detected, sessionFolder_, bookLang, READER_SETTINGS.dictionaryFolder);
+}
+
+void EpubDictionaryUi::setLangLabelFromFolder(const std::string& folderName) {
+  activeLangLabel_ = DictionaryRegistry::displayLabel(folderName, dict_.lang());
+  if (activeLangLabel_.empty() || activeLangLabel_ == "Auto") {
+    activeLangLabel_ = DictionaryRegistry::displayLabel(folderName, DictionaryRegistry::inferLangFromName(folderName));
+  }
+}
+
+void EpubDictionaryUi::layoutCurrentDefinition(EpubActivity& act, const bool truncated) {
+  if (truncated) {
+    while (!currentDefinition_.empty()) {
+      const auto last = static_cast<unsigned char>(currentDefinition_.back());
+      if ((last & 0xC0) == 0x80) {
+        currentDefinition_.pop_back();
+        continue;
+      }
+      if (last >= 0xC0) {
+        currentDefinition_.pop_back();
+      }
+      break;
+    }
+    currentDefinition_ += " \xE2\x80\xA6";
+  }
+
+  const bool parseHtml = ESP.getMaxAllocHeap() > 24000 && ESP.getFreeHeap() > 36000 &&
+                         currentDefinition_.find('<') != std::string::npos;
+  if (parseHtml) {
+    definitionBlocks_ = parseHtmlToBlocks(currentDefinition_);
+  } else {
+    DefinitionBlock block;
+    block.kind = DefinitionBlockKind::Paragraph;
+    block.runs.push_back(DefinitionTextRun(stripHtmlToPlain(currentDefinition_), EpdFontFamily::REGULAR));
+    definitionBlocks_.clear();
+    definitionBlocks_.push_back(std::move(block));
+  }
+  const int textWidth = (act.renderer.getScreenWidth() - kDefinitionPanelMargin * 2) - kDefinitionPanelPad * 2;
+  if (ESP.getMaxAllocHeap() > 16000) {
+    definitionLines_ = layoutDefinitionBlocks(act.renderer, definitionBlocks_, textWidth);
+  } else {
+    definitionLines_.clear();
+  }
+  if (definitionLines_.empty()) {
+    std::string plain = stripHtmlToPlain(currentDefinition_);
+    if (plain.empty()) {
+      plain = currentDefinition_;
+    }
+    if (!plain.empty()) {
+      const std::string clipped =
+          act.renderer.text.truncate(ATKINSON_HYPERLEGIBLE_10_FONT_ID, plain.c_str(), std::max(1, textWidth));
+      DefinitionStyledLine line;
+      line.fontId = ATKINSON_HYPERLEGIBLE_10_FONT_ID;
+      line.atoms.push_back(DefinitionTextAtom(clipped.empty() ? plain : clipped, EpdFontFamily::REGULAR, false, false));
+      definitionLines_.push_back(std::move(line));
+    }
+  }
+  definitionScrollLine_ = 0;
+}
+
+bool EpubDictionaryUi::lookupInFolder(EpubActivity& act, const std::string& folderName, const std::string& queryWord,
+                                      std::string& outDefinition, bool* outTruncated) {
+  if (folderName.empty() || queryWord.empty()) {
+    return false;
+  }
+  const std::string folder = std::string(DictionaryRegistry::kDictionariesRoot) + "/" + folderName;
+  const bool alreadyWarm = dict_.isOpen() && dict_.folderPath() == folder;
+  if (!alreadyWarm) {
+    act.readerPopup(StarDictLookup::needsIndexBuild(folder) ? "Indexing dictionary..." : "Opening dictionary...");
+  }
+  openFolder(folderName);
+  if (!dict_.isOpen()) {
+    return false;
+  }
+  return dict_.lookup(queryWord, outDefinition, outTruncated);
+}
+
+bool EpubDictionaryUi::tryUsefulLookup(EpubActivity& act, const std::string& folderName, const std::string& queryWord,
+                                       bool* outTruncated) {
+  std::vector<std::string> queries;
+  queries.push_back(queryWord);
+  for (const std::string& form : StarDictLookup::alternateForms(queryWord)) {
+    if (std::find(queries.begin(), queries.end(), form) == queries.end()) {
+      queries.push_back(form);
+    }
+  }
+
+  for (size_t i = 0; i < queries.size(); ++i) {
+    std::string def;
+    bool trunc = false;
+    if (!lookupInFolder(act, folderName, queries[i], def, &trunc)) {
+      continue;
+    }
+    if (definitionHasUsefulGloss(def)) {
+      currentDefinition_ = std::move(def);
+      if (outTruncated) {
+        *outTruncated = trunc;
+      }
+      return true;
+    }
+    const std::string lemma = lemmaFromDefinition(def);
+    if (!lemma.empty() && std::find(queries.begin(), queries.end(), lemma) == queries.end()) {
+      queries.push_back(lemma);
+    }
+    esp_task_wdt_reset();
+  }
+  return false;
+}
+
+void EpubDictionaryUi::cycleDictionary(EpubActivity& act, const int delta) {
+  const auto folders = DictionaryRegistry::foldersInFallbackOrder(preferredFolder_);
+  if (folders.size() < 2) {
+    return;
+  }
+  std::string current;
+  if (dict_.isOpen() && dict_.folderPath().size() > std::strlen(DictionaryRegistry::kDictionariesRoot) + 1) {
+    current = dict_.folderPath().substr(std::strlen(DictionaryRegistry::kDictionariesRoot) + 1);
+  } else {
+    current = preferredFolder_;
+  }
+  int idx = 0;
+  for (size_t i = 0; i < folders.size(); ++i) {
+    if (folders[i] == current) {
+      idx = static_cast<int>(i);
+      break;
+    }
+  }
+  idx = (idx + delta + static_cast<int>(folders.size())) % static_cast<int>(folders.size());
+  bool truncated = false;
+  currentDefinition_.clear();
+  const std::string& chosen = folders[static_cast<size_t>(idx)];
+  if (!tryUsefulLookup(act, chosen, lookedUpWord_, &truncated)) {
+    currentDefinition_ = "No definition found.";
+  }
+  sessionFolder_ = chosen;
+  preferredFolder_ = chosen;
+  usedFallbackDict_ = false;
+  setLangLabelFromFolder(chosen);
+  layoutCurrentDefinition(act, truncated);
+  act.updateRequired = true;
 }
 
 void EpubDictionaryUi::performLookup(EpubActivity& act) {
   if (words_.empty() || focus_ >= words_.size()) {
     return;
   }
-  lookedUpWord_ = stripSurroundingPunctuation(words_[focus_].text);
+  lookedUpWord_ = StarDictLookup::stripSurroundingPunctuation(words_[focus_].text);
   currentDefinition_.clear();
   definitionScrollLine_ = 0;
   wordAlreadySaved_ = !lookedUpWord_.empty() && SAVED_WORDS.contains(lookedUpWord_);
+  esp_task_wdt_reset();
 
   bool truncated = false;
+  usedFallbackDict_ = false;
+  activeLangLabel_.clear();
   if (lookedUpWord_.empty()) {
     currentDefinition_ = "Nothing to look up.";
-  } else if (READER_SETTINGS.dictionaryFolder[0] == '\0') {
-    currentDefinition_ = "No dictionary selected. Pick one in Settings > Reader > Choose dictionary.";
+  } else if (ESP.getFreeHeap() < 28000) {
+    currentDefinition_ = "Not enough memory for dictionary lookup.";
   } else {
-    const std::string folder = std::string("/dictionaries/") + READER_SETTINGS.dictionaryFolder;
-    const bool alreadyWarm = dict_.isOpen() && dict_.folderPath() == folder;
-    // Cold open (first lookup this session) can still take a second or two while checkpoints are
-    // built - show a toast so the device doesn't look frozen. Warm lookups aim to be near-instant,
-    // so skip the popup and avoid an extra full-screen e-ink refresh.
-    if (!alreadyWarm) {
-      act.readerPopup("Opening dictionary...");
-    }
-    ensureDictionaryOpen();
-    if (!dict_.isOpen()) {
-      currentDefinition_ = "Could not open the selected dictionary.";
-    } else if (!dict_.lookup(lookedUpWord_, currentDefinition_, &truncated)) {
-      currentDefinition_ = "No definition found.";
+    preferredFolder_ = resolvePreferredFolder(act);
+    esp_task_wdt_reset();
+    const std::vector<std::string> folders = DictionaryRegistry::foldersForAutoLookup(preferredFolder_);
+    if (folders.empty()) {
+      currentDefinition_ = "No dictionary selected. Add StarDict folders under /dictionaries/.";
+    } else {
+      bool found = false;
+      for (size_t i = 0; i < folders.size(); ++i) {
+        truncated = false;
+        currentDefinition_.clear();
+        if (tryUsefulLookup(act, folders[i], lookedUpWord_, &truncated)) {
+          found = true;
+          usedFallbackDict_ = i > 0;
+          if (i == 0) {
+            sessionFolder_ = folders[i];
+          }
+          setLangLabelFromFolder(folders[i]);
+          break;
+        }
+        esp_task_wdt_reset();
+      }
+      if (!found) {
+        currentDefinition_ = "No definition found.";
+        if (dict_.isOpen()) {
+          setLangLabelFromFolder(preferredFolder_);
+        }
+      }
     }
   }
-  if (truncated) {
-    // Back off from a cut that landed mid-UTF-8-codepoint (dictionaries are full of accented
-    // letters, IPA symbols, en/em dashes) so we never hand a malformed byte sequence to the parser.
-    while (!currentDefinition_.empty()) {
-      const auto last = static_cast<unsigned char>(currentDefinition_.back());
-      if ((last & 0xC0) == 0x80) {
-        currentDefinition_.pop_back();  // continuation byte - still mid-sequence
-        continue;
-      }
-      if (last >= 0xC0) {
-        currentDefinition_.pop_back();  // orphaned lead byte - its continuation got cut off
-      }
-      break;
-    }
-    currentDefinition_ += " \xE2\x80\xA6";
-  }
-  // Plain fallback messages above have no tags, so this is a no-op for them - it only does real work
-  // for an actual HTML definition. Keeps drawDefinitionPanel() dealing with a single block list always.
-  definitionBlocks_ = parseHtmlToBlocks(currentDefinition_);
-  // Laid out once here (not per-frame in drawDefinitionPanel) - see kMaxDefinitionRawBytes comment.
-  const int textWidth =
-      (act.renderer.getScreenWidth() - kDefinitionPanelMargin * 2) - kDefinitionPanelPad * 2;
-  definitionLines_ = layoutDefinitionBlocks(act.renderer, definitionBlocks_, textWidth);
+  layoutCurrentDefinition(act, truncated);
   showingDefinition_ = true;
   act.updateRequired = true;
 }
 
 bool EpubDictionaryUi::tryNavigationHoldRepeat(EpubActivity& act) {
-  using Btn = MappedInputManager::Button;
-  const MappedInputManager& m = act.mappedInput;
-  const unsigned long now = millis();
-
-  if (m.wasPressed(Btn::Left)) {
-    if (isDuplicateNavEdge(0, now)) {
-      return true;
-    }
-    moveFocusWord(-1);
-    navRepeatDir_ = 0;
-    navRepeatNextMs_ = now + kNavRepeatInitialMs;
+  WordOverlayNav::EdgeState edge{lastNavEdgeMs_, lastNavEdgeDir_};
+  const int nav = WordOverlayNav::handleDpad(
+      act.mappedInput, edge, navRepeatDir_, navRepeatNextMs_, millis(),
+      [this](const int delta) { moveFocusWord(delta); },
+      [this](const int delta, const bool wrap) { moveFocusLine(delta, wrap); });
+  lastNavEdgeMs_ = edge.lastMs;
+  lastNavEdgeDir_ = edge.lastDir;
+  if (nav == 2) {
     act.updateRequired = true;
-    return true;
   }
-  if (m.wasPressed(Btn::Right)) {
-    if (isDuplicateNavEdge(1, now)) {
-      return true;
-    }
-    moveFocusWord(1);
-    navRepeatDir_ = 1;
-    navRepeatNextMs_ = now + kNavRepeatInitialMs;
-    act.updateRequired = true;
-    return true;
-  }
-  if (m.wasPressed(Btn::Up)) {
-    if (isDuplicateNavEdge(2, now)) {
-      return true;
-    }
-    moveFocusLine(-1);
-    navRepeatDir_ = 2;
-    navRepeatNextMs_ = now + kNavRepeatInitialMs;
-    act.updateRequired = true;
-    return true;
-  }
-  if (m.wasPressed(Btn::Down)) {
-    if (isDuplicateNavEdge(3, now)) {
-      return true;
-    }
-    moveFocusLine(1);
-    navRepeatDir_ = 3;
-    navRepeatNextMs_ = now + kNavRepeatInitialMs;
-    act.updateRequired = true;
-    return true;
-  }
-  const bool leftHeld = m.isPressed(Btn::Left);
-  const bool rightHeld = m.isPressed(Btn::Right);
-  const bool upHeld = m.isPressed(Btn::Up);
-  const bool downHeld = m.isPressed(Btn::Down);
-  if (!leftHeld && !rightHeld && !upHeld && !downHeld) {
-    navRepeatDir_ = -1;
-    return false;
-  }
-  if (navRepeatDir_ < 0 || now < navRepeatNextMs_) {
-    return false;
-  }
-  if (navRepeatDir_ == 0 && leftHeld) {
-    moveFocusWord(-1);
-  } else if (navRepeatDir_ == 1 && rightHeld) {
-    moveFocusWord(1);
-  } else if (navRepeatDir_ == 2 && upHeld) {
-    // Auto-repeat covers 2 lines/tick (vs. 1 for the initial press) - holding Up/Down would
-    // otherwise take forever to cross a full page at kNavRepeatIntervalMs.
-    moveFocusLine(-1);
-    moveFocusLine(-1);
-  } else if (navRepeatDir_ == 3 && downHeld) {
-    moveFocusLine(1);
-    moveFocusLine(1);
-  } else {
-    navRepeatDir_ = -1;
-    return false;
-  }
-  navRepeatNextMs_ = now + kNavRepeatIntervalMs;
-  act.updateRequired = true;
-  return true;
+  return nav != 0;
 }
 
-/** Saves lookedUpWord_ to the global saved-words list (idempotent - a repeat Confirm on an
- *  already-saved word is a no-op). Just the word is stored, not the definition; the Recent activity's
- *  Dictionary list re-looks it up on open, so it stays correct even if the user switches dictionaries
- *  later - see SavedDictionaryWords.h. */
+/** Saves lookedUpWord_ plus the definition currently on screen. Idempotent — a repeat Confirm on an
+ *  already-saved word is a no-op. */
 void EpubDictionaryUi::saveCurrentWord(EpubActivity& act) {
   if (lookedUpWord_.empty() || wordAlreadySaved_) {
     return;
   }
-  if (SAVED_WORDS.add(lookedUpWord_, currentDefinition_)) {
+  std::string lang = DictionaryRegistry::primaryLanguageTag(dict_.lang());
+  if (lang.empty()) {
+    lang = DictionaryRegistry::inferLangFromName(sessionFolder_.empty() ? preferredFolder_ : sessionFolder_);
+  }
+  if (SAVED_WORDS.add(lookedUpWord_, currentDefinition_, lang)) {
     wordAlreadySaved_ = true;
     act.updateRequired = true;
   }
 }
 
 void EpubDictionaryUi::moveFocusWord(const int delta) {
-  if (words_.empty()) {
-    return;
-  }
-  if (delta < 0) {
-    if (focus_ > 0) {
-      focus_--;
-    }
-    return;
-  }
-  if (focus_ + 1 < words_.size()) {
-    focus_++;
-  }
+  WordOverlayNav::moveFocusWord(words_, focus_, delta);
 }
 
-void EpubDictionaryUi::moveFocusLine(const int delta) {
-  if (lineFirst_.empty() || words_.empty()) {
-    return;
-  }
-  size_t lineIdx = 0;
-  for (size_t i = 0; i < lineFirst_.size(); ++i) {
-    const size_t start = lineFirst_[i];
-    const size_t end = (i + 1 < lineFirst_.size()) ? lineFirst_[i + 1] : words_.size();
-    if (focus_ >= start && focus_ < end) {
-      lineIdx = i;
-      break;
-    }
-  }
-  if (delta < 0) {
-    if (lineIdx == 0) {
-      return;
-    }
-    lineIdx--;
-    focus_ = lineFirst_[lineIdx];
-  } else {
-    if (lineIdx + 1 >= lineFirst_.size()) {
-      return;
-    }
-    lineIdx++;
-    focus_ = lineFirst_[lineIdx];
-  }
+void EpubDictionaryUi::moveFocusLine(const int delta, const bool wrap) {
+  WordOverlayNav::moveFocusLine(words_, lineFirst_, focus_, delta, wrap);
 }
 
 void EpubDictionaryUi::handleInput(EpubActivity& act) {
@@ -452,6 +527,10 @@ void EpubDictionaryUi::handleInput(EpubActivity& act) {
     } else if (m.wasPressed(MappedInputManager::Button::Down)) {
       definitionScrollLine_ += kScrollLinesPerPress;
       act.updateRequired = true;
+    } else if (m.wasReleased(MappedInputManager::Button::Left)) {
+      cycleDictionary(act, -1);
+    } else if (m.wasReleased(MappedInputManager::Button::Right)) {
+      cycleDictionary(act, 1);
     }
     return;
   }
@@ -546,12 +625,26 @@ void EpubDictionaryUi::drawDefinitionPanel(EpubActivity& act) {
 
   int y = panelTop + pad + titleH;
   act.renderer.text.render(titleFontId, panelX + pad, y - titleH, lookedUpWord_.c_str(), true, EpdFontFamily::BOLD);
-  if (wordAlreadySaved_) {
+  {
     const int tagFontId = ATKINSON_HYPERLEGIBLE_8_FONT_ID;
-    const char* tag = "\xE2\x98\x85 Saved";  // "* Saved"
-    const int tagW = act.renderer.text.getWidth(tagFontId, tag);
-    const int tagY = y - titleH + (titleH - act.renderer.text.getLineHeight(tagFontId)) / 2;
-    act.renderer.text.render(tagFontId, panelX + panelW - pad - tagW, tagY, tag, true);
+    std::string tag;
+    if (wordAlreadySaved_) {
+      tag = "\xE2\x98\x85 Saved";
+    }
+    if (!activeLangLabel_.empty() && activeLangLabel_ != "Auto") {
+      if (!tag.empty()) {
+        tag += "  ";
+      }
+      tag += activeLangLabel_;
+      if (usedFallbackDict_) {
+        tag += "?";
+      }
+    }
+    if (!tag.empty()) {
+      const int tagW = act.renderer.text.getWidth(tagFontId, tag.c_str());
+      const int tagY = y - titleH + (titleH - act.renderer.text.getLineHeight(tagFontId)) / 2;
+      act.renderer.text.render(tagFontId, panelX + panelW - pad - tagW, tagY, tag.c_str(), true);
+    }
   }
   y += kTitleGapPx;
   act.renderer.line.render(panelX + pad, y, panelX + panelW - pad, y, true, LineRender::Style::Dotted);
@@ -595,7 +688,9 @@ void EpubDictionaryUi::drawUiOverlay(EpubActivity& act) {
   act.renderer.setOrientation(GfxRenderer::Portrait);
   const char* back = showingDefinition_ ? "Close" : "Exit";
   const char* mid = showingDefinition_ ? (wordAlreadySaved_ ? "Saved" : "Save") : "Look up";
-  const auto labels = act.mappedInput.mapLabels(back, mid, "Prev", "Next");
+  const char* leftHint = showingDefinition_ ? "Lang" : "Prev";
+  const char* rightHint = showingDefinition_ ? "Lang" : "Next";
+  const auto labels = act.mappedInput.mapLabels(back, mid, leftHint, rightHint);
   act.renderer.ui.buttonHints(ATKINSON_HYPERLEGIBLE_10_FONT_ID, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
   const bool showUpDown = !showingDefinition_ || definitionScrollable_;
   act.renderer.ui.sideButtonHints(ATKINSON_HYPERLEGIBLE_10_FONT_ID, "", showUpDown ? "Up" : "", showUpDown ? "Down" : "");

--- a/src/activity/reader/Epub/EpubDictionaryUi.h
+++ b/src/activity/reader/Epub/EpubDictionaryUi.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "dictionary/DictionaryDefinitionLayout.h"
+#include "dictionary/DictionaryRegistry.h"
 #include "dictionary/StarDictLookup.h"
 
 class EpubActivity;
@@ -35,14 +36,21 @@ class EpubDictionaryUi {
   void prepareWordGeometry(EpubActivity& act);
   void captureFramebuffer(EpubActivity& act);
   void moveFocusWord(int delta);
-  void moveFocusLine(int delta);
+  void moveFocusLine(int delta, bool wrap);
   bool tryNavigationHoldRepeat(EpubActivity& act);
-  bool isDuplicateNavEdge(int dir, unsigned long now);
   void drawFocusHighlight(EpubActivity& act);
   void drawDefinitionPanel(EpubActivity& act);
   void performLookup(EpubActivity& act);
-  void ensureDictionaryOpen();
+  void ensureDictionaryOpen(EpubActivity& act);
+  void openFolder(const std::string& folderName);
+  bool lookupInFolder(EpubActivity& act, const std::string& folderName, const std::string& queryWord,
+                      std::string& outDefinition, bool* outTruncated);
+  bool tryUsefulLookup(EpubActivity& act, const std::string& folderName, const std::string& queryWord, bool* outTruncated);
+  void cycleDictionary(EpubActivity& act, int delta);
   void saveCurrentWord(EpubActivity& act);
+  std::string resolvePreferredFolder(EpubActivity& act);
+  void setLangLabelFromFolder(const std::string& folderName);
+  void layoutCurrentDefinition(EpubActivity& act, bool truncated);
   /** Actually releases currentDefinition_/definitionBlocks_/definitionLines_'s heap capacity (not
    *  just .clear(), which keeps it reserved for reuse) - a big dictionary entry's parsed/laid-out
    *  form can run into the tens of KB, and .clear() alone would leave that reserved for as long as
@@ -55,6 +63,10 @@ class EpubDictionaryUi {
   size_t focus_ = 0;
 
   StarDictLookup dict_;
+  std::string preferredFolder_;
+  std::string sessionFolder_;
+  std::string activeLangLabel_;
+  bool usedFallbackDict_ = false;
   bool showingDefinition_ = false;
   std::string lookedUpWord_;
   bool wordAlreadySaved_ = false;

--- a/src/activity/reader/Epub/WordOverlayNav.h
+++ b/src/activity/reader/Epub/WordOverlayNav.h
@@ -1,0 +1,203 @@
+#pragma once
+
+/**
+ * Shared D-pad movement for highlight + dictionary word pickers.
+ *
+ * Up on the first line jumps to the last word on the page (so the bottom is one press away).
+ * Down on the last line jumps to the first word. A second press of the same button within a short
+ * window skips several words/lines. Hold-repeat does not wrap, so a held Down stops at the bottom.
+ */
+
+#include <Epub/PageWordIndex.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdlib>
+#include <vector>
+
+#include "system/MappedInputManager.h"
+
+namespace WordOverlayNav {
+
+constexpr unsigned long kBounceMs = 50;
+constexpr unsigned long kDoubleTapMs = 340;
+constexpr int kDoubleTapStride = 3;
+constexpr unsigned long kRepeatInitialMs = 700;
+constexpr unsigned long kRepeatIntervalMs = 95;
+constexpr int kRepeatLineStride = 3;
+constexpr int kRepeatWordStride = 3;
+
+struct EdgeState {
+  unsigned long lastMs = 0;
+  int lastDir = -1;
+  EdgeState() = default;
+  EdgeState(unsigned long ms, int dir) : lastMs(ms), lastDir(dir) {}
+};
+
+inline bool isBounce(EdgeState& state, const int dir, const unsigned long now) {
+  if (state.lastDir == dir && (now - state.lastMs) < kBounceMs) {
+    state.lastMs = now;
+    return true;
+  }
+  return false;
+}
+
+inline int stepsForPress(EdgeState& state, const int dir, const unsigned long now) {
+  const int steps =
+      (state.lastDir == dir && (now - state.lastMs) < kDoubleTapMs) ? kDoubleTapStride : 1;
+  state.lastMs = now;
+  state.lastDir = dir;
+  return steps;
+}
+
+inline void moveFocusWord(const std::vector<PageWordHit>& words, size_t& focus, const int delta) {
+  if (words.empty() || delta == 0) {
+    return;
+  }
+  if (delta > 0) {
+    const size_t room = words.size() - 1 - focus;
+    focus += std::min(static_cast<size_t>(delta), room);
+    return;
+  }
+  const size_t back = static_cast<size_t>(-delta);
+  focus = (back >= focus) ? 0 : focus - back;
+}
+
+inline size_t lineIndexForFocus(const std::vector<size_t>& lineFirst, const size_t wordCount, const size_t focus) {
+  if (lineFirst.empty()) {
+    return 0;
+  }
+  size_t lineIdx = 0;
+  for (size_t i = 0; i < lineFirst.size(); ++i) {
+    const size_t start = lineFirst[i];
+    const size_t end = (i + 1 < lineFirst.size()) ? lineFirst[i + 1] : wordCount;
+    if (focus >= start && focus < end) {
+      lineIdx = i;
+      break;
+    }
+  }
+  return lineIdx;
+}
+
+inline size_t wordOnLineNearestX(const std::vector<PageWordHit>& words, const std::vector<size_t>& lineFirst,
+                                 const size_t lineIdx, const int targetX) {
+  const size_t start = lineFirst[lineIdx];
+  const size_t end = (lineIdx + 1 < lineFirst.size()) ? lineFirst[lineIdx + 1] : words.size();
+  size_t best = start;
+  int bestDist = 0x7fffffff;
+  for (size_t i = start; i < end; ++i) {
+    const int cx = words[i].screenX + words[i].screenW / 2;
+    const int dist = std::abs(cx - targetX);
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = i;
+    }
+  }
+  return best;
+}
+
+/** @param wrap If true, Up on the first line goes to the last word and Down on the last line goes
+ *  to the first word. Remaining steps after a wrap are ignored so that jump lands on the end. */
+inline void moveFocusLine(const std::vector<PageWordHit>& words, const std::vector<size_t>& lineFirst, size_t& focus,
+                          const int delta, const bool wrap) {
+  if (words.empty() || lineFirst.empty() || delta == 0) {
+    return;
+  }
+  size_t lineIdx = lineIndexForFocus(lineFirst, words.size(), focus);
+  const int targetX = words[focus].screenX + words[focus].screenW / 2;
+  const int sign = delta > 0 ? 1 : -1;
+  int remaining = delta > 0 ? delta : -delta;
+  while (remaining > 0) {
+    if (sign < 0) {
+      if (lineIdx == 0) {
+        if (wrap) {
+          focus = words.size() - 1;
+        }
+        return;
+      }
+      --lineIdx;
+    } else {
+      if (lineIdx + 1 >= lineFirst.size()) {
+        if (wrap) {
+          focus = 0;
+        }
+        return;
+      }
+      ++lineIdx;
+    }
+    --remaining;
+  }
+  focus = wordOnLineNearestX(words, lineFirst, lineIdx, targetX);
+}
+
+/** @return 0 none, 1 bounce consumed (no move), 2 moved */
+template <typename MoveWord, typename MoveLine>
+int handleDpad(const MappedInputManager& mapped, EdgeState& edge, int& repeatDir, unsigned long& repeatNextMs,
+               const unsigned long now, MoveWord&& moveWord, MoveLine&& moveLine) {
+  using Btn = MappedInputManager::Button;
+
+  if (mapped.wasPressed(Btn::Left)) {
+    if (isBounce(edge, 0, now)) {
+      return 1;
+    }
+    moveWord(-stepsForPress(edge, 0, now));
+    repeatDir = 0;
+    repeatNextMs = now + kRepeatInitialMs;
+    return 2;
+  }
+  if (mapped.wasPressed(Btn::Right)) {
+    if (isBounce(edge, 1, now)) {
+      return 1;
+    }
+    moveWord(stepsForPress(edge, 1, now));
+    repeatDir = 1;
+    repeatNextMs = now + kRepeatInitialMs;
+    return 2;
+  }
+  if (mapped.wasPressed(Btn::Up)) {
+    if (isBounce(edge, 2, now)) {
+      return 1;
+    }
+    moveLine(-stepsForPress(edge, 2, now), true);
+    repeatDir = 2;
+    repeatNextMs = now + kRepeatInitialMs;
+    return 2;
+  }
+  if (mapped.wasPressed(Btn::Down)) {
+    if (isBounce(edge, 3, now)) {
+      return 1;
+    }
+    moveLine(stepsForPress(edge, 3, now), true);
+    repeatDir = 3;
+    repeatNextMs = now + kRepeatInitialMs;
+    return 2;
+  }
+
+  const bool leftHeld = mapped.isPressed(Btn::Left);
+  const bool rightHeld = mapped.isPressed(Btn::Right);
+  const bool upHeld = mapped.isPressed(Btn::Up);
+  const bool downHeld = mapped.isPressed(Btn::Down);
+  if (!leftHeld && !rightHeld && !upHeld && !downHeld) {
+    repeatDir = -1;
+    return 0;
+  }
+  if (repeatDir < 0 || now < repeatNextMs) {
+    return 0;
+  }
+  if (repeatDir == 0 && leftHeld) {
+    moveWord(-kRepeatWordStride);
+  } else if (repeatDir == 1 && rightHeld) {
+    moveWord(kRepeatWordStride);
+  } else if (repeatDir == 2 && upHeld) {
+    moveLine(-kRepeatLineStride, false);
+  } else if (repeatDir == 3 && downHeld) {
+    moveLine(kRepeatLineStride, false);
+  } else {
+    repeatDir = -1;
+    return 0;
+  }
+  repeatNextMs = now + kRepeatIntervalMs;
+  return 2;
+}
+
+}  // namespace WordOverlayNav

--- a/src/activity/settings/DictionaryPickerActivity.cpp
+++ b/src/activity/settings/DictionaryPickerActivity.cpp
@@ -4,54 +4,17 @@
 #include <SDCardManager.h>
 
 #include <algorithm>
+#include <cstring>
 
 #include "state/ReaderSetting.h"
 #include "state/SystemSetting.h"
 #include "system/Fonts.h"
 #include "system/MappedInputManager.h"
-#include "system/MenuNav.h"
 #include "system/UiTheme.h"
-#include "util/StringUtils.h"
 
 namespace {
 constexpr int kBodyFont = ATKINSON_HYPERLEGIBLE_10_FONT_ID;
 constexpr int kRowH = UiTheme::DRAWER_LIST_ITEM_HEIGHT;
-constexpr const char* kDictionariesRoot = "/dictionaries";
-
-/** A folder counts as a dictionary if it directly contains at least one .idx and one .dict file. */
-bool folderLooksLikeDictionary(const std::string& folderPath) {
-  FsFile dir = SdMan.open(folderPath.c_str());
-  if (!dir || !dir.isDirectory()) {
-    if (dir) {
-      dir.close();
-    }
-    return false;
-  }
-  bool hasIdx = false;
-  bool hasDict = false;
-  for (FsFile file = dir.openNextFile(); file; file = dir.openNextFile()) {
-    if (!file.isDirectory()) {
-      char name[160] = {};
-      file.getName(name, sizeof(name));
-      // Skip macOS AppleDouble sidecar junk ("._real.idx" etc), same as StarDictLookup::open().
-      if (name[0] == '.') {
-        file.close();
-        continue;
-      }
-      if (StringUtils::checkFileExtension(std::string(name), ".idx")) {
-        hasIdx = true;
-      } else if (StringUtils::checkFileExtension(std::string(name), ".dict")) {
-        hasDict = true;
-      }
-    }
-    file.close();
-    if (hasIdx && hasDict) {
-      break;
-    }
-  }
-  dir.close();
-  return hasIdx && hasDict;
-}
 }  // namespace
 
 void DictionaryPickerActivity::onEnter() {
@@ -61,39 +24,39 @@ void DictionaryPickerActivity::onEnter() {
 }
 
 void DictionaryPickerActivity::scanDictionaryFolders() {
-  folders_.clear();
+  entries_ = DictionaryRegistry::scan();
   selectedIndex_ = 0;
   scrollOffset_ = 0;
 
-  FsFile dir = SdMan.open(kDictionariesRoot);
-  if (!dir || !dir.isDirectory()) {
-    if (dir) {
-      dir.close();
-    }
-    return;
-  }
-
-  for (FsFile file = dir.openNextFile(); file; file = dir.openNextFile()) {
-    if (file.isDirectory()) {
-      char name[160] = {};
-      file.getName(name, sizeof(name));
-      const std::string folderPath = std::string(kDictionariesRoot) + "/" + name;
-      if (folderLooksLikeDictionary(folderPath)) {
-        folders_.push_back(name);
+  if (READER_SETTINGS.dictionaryFolder[0] != '\0') {
+    for (size_t i = 0; i < entries_.size(); ++i) {
+      if (entries_[i].folder == READER_SETTINGS.dictionaryFolder) {
+        selectedIndex_ = static_cast<int>(i);
+        break;
       }
     }
-    file.close();
   }
-  dir.close();
+}
 
-  std::sort(folders_.begin(), folders_.end());
-
-  if (READER_SETTINGS.dictionaryFolder[0] != '\0') {
-    const auto it = std::find(folders_.begin(), folders_.end(), std::string(READER_SETTINGS.dictionaryFolder));
-    if (it != folders_.end()) {
-      selectedIndex_ = static_cast<int>(std::distance(folders_.begin(), it));
+void DictionaryPickerActivity::cycleSelectedLang(const int delta) {
+  if (entries_.empty()) {
+    return;
+  }
+  DictionaryRegistry::Entry& entry = entries_[static_cast<size_t>(selectedIndex_)];
+  const std::string currentOverride = DictionaryRegistry::overrideFor(entry.folder);
+  int idx = DictionaryRegistry::langCycleIndex(currentOverride);
+  idx = (idx + delta + DictionaryRegistry::kLangCycleCount) % DictionaryRegistry::kLangCycleCount;
+  const char* next = DictionaryRegistry::kLangCycle[idx];
+  DictionaryRegistry::setOverride(entry.folder, next);
+  if (next[0] == '\0') {
+    entry.lang = DictionaryRegistry::readIfoLang(std::string(DictionaryRegistry::kDictionariesRoot) + "/" + entry.folder);
+    if (entry.lang.empty()) {
+      entry.lang = DictionaryRegistry::inferLangFromName(entry.folder);
     }
+  } else {
+    entry.lang = next;
   }
+  render();
 }
 
 void DictionaryPickerActivity::loop() {
@@ -102,23 +65,31 @@ void DictionaryPickerActivity::loop() {
     return;
   }
 
-  const int total = static_cast<int>(folders_.size());
+  const int total = static_cast<int>(entries_.size());
   if (total == 0) {
     return;
   }
 
-  if (mappedInput.wasPressed(MenuNav::itemNext())) {
+  if (mappedInput.wasPressed(MappedInputManager::Button::Down)) {
     selectedIndex_ = (selectedIndex_ + 1) % total;
     render();
     return;
   }
-  if (mappedInput.wasPressed(MenuNav::itemPrev())) {
+  if (mappedInput.wasPressed(MappedInputManager::Button::Up)) {
     selectedIndex_ = (selectedIndex_ + total - 1) % total;
     render();
     return;
   }
+  if (mappedInput.wasPressed(MappedInputManager::Button::Left)) {
+    cycleSelectedLang(-1);
+    return;
+  }
+  if (mappedInput.wasPressed(MappedInputManager::Button::Right)) {
+    cycleSelectedLang(1);
+    return;
+  }
   if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
-    const std::string& chosen = folders_[static_cast<size_t>(selectedIndex_)];
+    const std::string& chosen = entries_[static_cast<size_t>(selectedIndex_)].folder;
     strncpy(READER_SETTINGS.dictionaryFolder, chosen.c_str(), sizeof(READER_SETTINGS.dictionaryFolder) - 1);
     READER_SETTINGS.dictionaryFolder[sizeof(READER_SETTINGS.dictionaryFolder) - 1] = '\0';
     READER_SETTINGS.saveToFile();
@@ -131,14 +102,16 @@ void DictionaryPickerActivity::render() {
   renderer.clearScreen();
   const int screenW = renderer.getScreenWidth();
   const int screenH = renderer.getScreenHeight();
-  const int bodyTop = INX_THEME.drawPageHeader(renderer, "Choose dictionary");
+  const int bodyTop = INX_THEME.drawPageHeader(renderer, "Choose dictionaries");
 
-  const int total = static_cast<int>(folders_.size());
+  const int total = static_cast<int>(entries_.size());
   if (total == 0) {
     const int centerY = bodyTop + (screenH - bodyTop - 80) / 2;
     renderer.text.centered(kBodyFont, centerY, "No dictionaries found.", true, EpdFontFamily::BOLD);
     renderer.text.centered(kBodyFont, centerY + 32, "Put StarDict folders under /dictionaries/", true,
                            EpdFontFamily::REGULAR);
+    renderer.text.centered(ATKINSON_HYPERLEGIBLE_8_FONT_ID, centerY + 56, "One folder per language. All of them are used.",
+                           true, EpdFontFamily::REGULAR);
     const auto hints = mappedInput.mapLabels("\xC2\xAB Back", "", "", "");
     renderer.ui.buttonHints(kBodyFont, hints.btn1, hints.btn2, hints.btn3, hints.btn4);
     renderer.displayBuffer();
@@ -159,20 +132,23 @@ void DictionaryPickerActivity::render() {
   for (int i = scrollOffset_; i < endIndex; ++i) {
     const int y = bodyTop + (i - scrollOffset_) * kRowH;
     const bool selected = i == selectedIndex_;
-    const bool active = folders_[static_cast<size_t>(i)] == READER_SETTINGS.dictionaryFolder;
+    const bool active = entries_[static_cast<size_t>(i)].folder == READER_SETTINGS.dictionaryFolder;
     if (selected) {
       renderer.rectangle.fill(0, y, screenW, kRowH, static_cast<int>(GfxRenderer::FillTone::Ink));
     }
-    const int titleY = y + (kRowH - renderer.text.getLineHeight(kBodyFont)) / 2;
-    std::string label = folders_[static_cast<size_t>(i)];
+    const int titleY = y + (kRowH - renderer.text.getLineHeight(kBodyFont)) / 2 - 8;
+    const int subY = titleY + renderer.text.getLineHeight(kBodyFont) + 2;
+    std::string label = entries_[static_cast<size_t>(i)].folder;
     if (active) {
-      label += "  \xE2\x9C\x93";  // checkmark on the currently active dictionary
+      label += "  \xE2\x9C\x93";
     }
     renderer.text.render(kBodyFont, 20, titleY, label.c_str(), !selected, EpdFontFamily::REGULAR);
+    const std::string langLine = DictionaryRegistry::langLabel(entries_[static_cast<size_t>(i)].lang);
+    renderer.text.render(ATKINSON_HYPERLEGIBLE_8_FONT_ID, 20, subY, langLine.c_str(), !selected, EpdFontFamily::REGULAR);
     renderer.line.render(0, y + kRowH - 1, screenW, y + kRowH - 1, true, LineRender::Style::Dotted);
   }
 
-  const auto hints = mappedInput.mapLabels("\xC2\xAB Back", "Select", "Up", "Down");
+  const auto hints = mappedInput.mapLabels("\xC2\xAB Back", "Fallback", "Lang", "Lang");
   renderer.ui.buttonHints(kBodyFont, hints.btn1, hints.btn2, hints.btn3, hints.btn4);
   renderer.displayBuffer();
 }

--- a/src/activity/settings/DictionaryPickerActivity.h
+++ b/src/activity/settings/DictionaryPickerActivity.h
@@ -2,7 +2,10 @@
 
 /**
  * @file DictionaryPickerActivity.h
- * @brief Picks the active dictionary from /dictionaries/<folder> for EPUB dictionary lookup.
+ * @brief Lists StarDict folders under /dictionaries and assigns language tags.
+ *
+ * Every installed folder is used at lookup time. Confirm only sets the fallback for when
+ * passage-language detection is unsure.
  */
 
 #include <functional>
@@ -10,6 +13,7 @@
 #include <vector>
 
 #include "activity/ActivityWithSubactivity.h"
+#include "dictionary/DictionaryRegistry.h"
 
 class DictionaryPickerActivity final : public ActivityWithSubactivity {
  public:
@@ -21,11 +25,12 @@ class DictionaryPickerActivity final : public ActivityWithSubactivity {
   void loop() override;
 
  private:
-  std::vector<std::string> folders_;
+  std::vector<DictionaryRegistry::Entry> entries_;
   int selectedIndex_ = 0;
   int scrollOffset_ = 0;
   const std::function<void()> goBack_;
 
   void scanDictionaryFolders();
+  void cycleSelectedLang(int delta);
   void render();
 };

--- a/src/dictionary/DictionaryDefinitionLayout.cpp
+++ b/src/dictionary/DictionaryDefinitionLayout.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 
 #include "system/Fonts.h"
 
@@ -173,9 +174,85 @@ int fontIdForBlock(const DefinitionBlock& block) {
   return ATKINSON_HYPERLEGIBLE_12_FONT_ID;
 }
 
+std::string asciiLowerCopy(std::string s) {
+  for (char& c : s) {
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  return s;
+}
+
+/** Drops WikDict / FreeDict IPA: gray <font> runs and slash-wrapped transcriptions like /ti.t/. */
+std::string stripPhoneticMarkup(const std::string& html) {
+  std::string withoutFont;
+  withoutFont.reserve(html.size());
+  size_t i = 0;
+  while (i < html.size()) {
+    if (html[i] == '<') {
+      const size_t close = html.find('>', i);
+      if (close == std::string::npos) {
+        break;
+      }
+      const std::string inner = asciiLowerCopy(html.substr(i + 1, close - i - 1));
+      if (inner.compare(0, 4, "font") == 0 && inner.find("gray") != std::string::npos) {
+        if (!withoutFont.empty() && withoutFont.back() == '/') {
+          withoutFont.pop_back();
+        }
+        size_t end = close + 1;
+        while (end < html.size()) {
+          const size_t next = html.find('<', end);
+          if (next == std::string::npos) {
+            end = html.size();
+            break;
+          }
+          const size_t nextClose = html.find('>', next);
+          if (nextClose == std::string::npos) {
+            end = html.size();
+            break;
+          }
+          const std::string nextInner = asciiLowerCopy(html.substr(next + 1, nextClose - next - 1));
+          end = nextClose + 1;
+          if (nextInner == "/font") {
+            break;
+          }
+        }
+        i = end;
+        while (i < html.size() && (html[i] == '/' || html[i] == ',' || html[i] == ' ')) {
+          ++i;
+        }
+        continue;
+      }
+    }
+    withoutFont.push_back(html[i]);
+    ++i;
+  }
+
+  std::string out;
+  out.reserve(withoutFont.size());
+  i = 0;
+  while (i < withoutFont.size()) {
+    if (withoutFont[i] == '/') {
+      size_t j = i + 1;
+      while (j < withoutFont.size() && withoutFont[j] != '/' && withoutFont[j] != '<') {
+        ++j;
+      }
+      if (j < withoutFont.size() && withoutFont[j] == '/' && (j - i) < 48) {
+        i = j + 1;
+        while (i < withoutFont.size() && (withoutFont[i] == ',' || withoutFont[i] == ' ')) {
+          ++i;
+        }
+        continue;
+      }
+    }
+    out.push_back(withoutFont[i]);
+    ++i;
+  }
+  return out;
+}
+
 }  // namespace
 
 std::vector<DefinitionBlock> parseHtmlToBlocks(const std::string& html) {
+  const std::string source = stripPhoneticMarkup(html);
   std::vector<DefinitionBlock> blocks;
   DefinitionBlock current;
   current.runs.push_back(DefinitionTextRun{});
@@ -227,13 +304,13 @@ std::vector<DefinitionBlock> parseHtmlToBlocks(const std::string& html) {
   };
 
   size_t i = 0;
-  while (i < html.size()) {
-    if (html[i] == '<') {
-      const size_t close = html.find('>', i);
+  while (i < source.size()) {
+    if (source[i] == '<') {
+      const size_t close = source.find('>', i);
       if (close == std::string::npos) {
         break;  // unterminated tag - stop rather than emit garbage
       }
-      std::string tag = html.substr(i + 1, close - i - 1);
+      std::string tag = source.substr(i + 1, close - i - 1);
       i = close + 1;
       const bool closing = !tag.empty() && tag[0] == '/';
       if (closing) {
@@ -286,7 +363,7 @@ std::vector<DefinitionBlock> parseHtmlToBlocks(const std::string& html) {
       continue;
     }
     ensureRunStyle();
-    appendCollapsedChar(current, html[i]);
+    appendCollapsedChar(current, source[i]);
     ++i;
   }
   flush();
@@ -349,4 +426,202 @@ void renderStyledLines(GfxRenderer& renderer, const std::vector<DefinitionStyled
     }
     y += lineH;
   }
+}
+
+namespace {
+
+std::string htmlToCollapsedPlain(const std::string& html) {
+  const std::string source = stripPhoneticMarkup(html);
+  std::string out;
+  out.reserve(source.size());
+  bool inTag = false;
+  for (unsigned char c : source) {
+    if (c == '<') {
+      inTag = true;
+      continue;
+    }
+    if (c == '>') {
+      inTag = false;
+      if (!out.empty() && out.back() != ' ') {
+        out.push_back(' ');
+      }
+      continue;
+    }
+    if (inTag) {
+      continue;
+    }
+    if (c <= ' ' || c == '\t' || c == '\n' || c == '\r') {
+      if (!out.empty() && out.back() != ' ') {
+        out.push_back(' ');
+      }
+      continue;
+    }
+    if (c >= 'A' && c <= 'Z') {
+      c = static_cast<unsigned char>(c - 'A' + 'a');
+    }
+    out.push_back(static_cast<char>(c));
+  }
+  while (!out.empty() && out.back() == ' ') {
+    out.pop_back();
+  }
+  return decodeHtmlEntities(out);
+}
+
+const char* const kFormOfMarkers[] = {
+    "past participle of",
+    "present participle of",
+    "gerund of",
+    "simple past of",
+    "past tense of",
+    "third-person singular of",
+    "third person singular of",
+    "third-person singular",
+    "inflected form of",
+    "conjugated form of",
+    "comparative of",
+    "superlative of",
+    "plural of",
+    "voltooid deelwoord van",
+    "tegenwoordig deelwoord van",
+    "onvoltooid deelwoord van",
+    "verleden tijd van",
+    "meervoud van",
+    "verkleinwoord van",
+    "vervoeging van",
+    "verbuiging van",
+    "participe passe de",
+    "forme flechie de",
+};
+
+bool isWordChar(const unsigned char c) {
+  return c >= 0x80 || std::isalnum(c) != 0 || c == '\'' || c == '-';
+}
+
+void skipSpaces(const std::string& s, size_t& i) {
+  while (i < s.size() && s[i] == ' ') {
+    ++i;
+  }
+}
+
+bool consumeWord(const std::string& s, size_t& i, const char* word) {
+  const size_t n = std::strlen(word);
+  if (i + n <= s.size() && s.compare(i, n, word) == 0) {
+    const size_t after = i + n;
+    if (after == s.size() || s[after] == ' ') {
+      i = after;
+      skipSpaces(s, i);
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string firstLemmaToken(const std::string& s, size_t i) {
+  skipSpaces(s, i);
+  (void)consumeWord(s, i, "to");
+  (void)consumeWord(s, i, "the");
+  (void)consumeWord(s, i, "a");
+  (void)consumeWord(s, i, "an");
+  (void)consumeWord(s, i, "het");
+  (void)consumeWord(s, i, "de");
+  (void)consumeWord(s, i, "een");
+  const size_t start = i;
+  while (i < s.size() && isWordChar(static_cast<unsigned char>(s[i]))) {
+    ++i;
+  }
+  if (i - start < 2) {
+    return "";
+  }
+  return s.substr(start, i - start);
+}
+
+void eraseFormOfClauses(std::string& plain) {
+  for (const char* marker : kFormOfMarkers) {
+    const size_t markerLen = std::strlen(marker);
+    size_t p = 0;
+    while ((p = plain.find(marker, p)) != std::string::npos) {
+      size_t end = p + markerLen;
+      skipSpaces(plain, end);
+      int words = 0;
+      while (end < plain.size() && words < 4) {
+        if (plain[end] == ' ') {
+          ++words;
+          skipSpaces(plain, end);
+          continue;
+        }
+        if (!isWordChar(static_cast<unsigned char>(plain[end]))) {
+          break;
+        }
+        ++end;
+      }
+      plain.erase(p, end - p);
+    }
+  }
+}
+
+}  // namespace
+
+std::string lemmaFromDefinition(const std::string& html) {
+  const std::string plain = htmlToCollapsedPlain(html);
+  for (const char* marker : kFormOfMarkers) {
+    const size_t p = plain.find(marker);
+    if (p == std::string::npos) {
+      continue;
+    }
+    const std::string lemma = firstLemmaToken(plain, p + std::strlen(marker));
+    if (!lemma.empty()) {
+      return lemma;
+    }
+  }
+  return "";
+}
+
+bool definitionHasUsefulGloss(const std::string& html) {
+  std::string plain = htmlToCollapsedPlain(html);
+  if (plain.empty()) {
+    return false;
+  }
+  eraseFormOfClauses(plain);
+
+  static const char* kPos[] = {"verb",
+                               "noun",
+                               "adjective",
+                               "adverb",
+                               "pronoun",
+                               "preposition",
+                               "conjunction",
+                               "interjection",
+                               "article",
+                               "determiner",
+                               "werkwoord",
+                               "zelfstandig naamwoord",
+                               "bijvoeglijk naamwoord",
+                               "bijwoord",
+                               "lidwoord",
+                               "verbe",
+                               "nom",
+                               "adjectif",
+                               "adverbe",
+                               "substantief"};
+  for (const char* pos : kPos) {
+    const size_t n = std::strlen(pos);
+    size_t p = 0;
+    while ((p = plain.find(pos, p)) != std::string::npos) {
+      const bool startOk = p == 0 || plain[p - 1] == ' ';
+      const bool endOk = p + n == plain.size() || plain[p + n] == ' ';
+      if (startOk && endOk) {
+        plain.erase(p, n);
+      } else {
+        ++p;
+      }
+    }
+  }
+
+  int letters = 0;
+  for (unsigned char c : plain) {
+    if (std::isalnum(c) != 0 || c >= 0x80) {
+      ++letters;
+    }
+  }
+  return letters >= 24;
 }

--- a/src/dictionary/DictionaryDefinitionLayout.h
+++ b/src/dictionary/DictionaryDefinitionLayout.h
@@ -79,3 +79,13 @@ std::vector<DefinitionStyledLine> layoutDefinitionBlocks(const GfxRenderer& rend
  *  (for scrollable panels like EpubDictionaryUi's) and stopping once a line would cross bottomLimit. */
 void renderStyledLines(GfxRenderer& renderer, const std::vector<DefinitionStyledLine>& lines, int x, int startY,
                        int bottomLimit, size_t startIndex = 0);
+
+/**
+ * True when a StarDict HTML definition contains a real gloss, not just a part-of-speech tag and/or
+ * "past participle of X" / "voltooid deelwoord van X" inflection stub. Translation Wiktionary dumps
+ * often store inflected forms as those stubs; callers should then look up the lemma or another dict.
+ */
+bool definitionHasUsefulGloss(const std::string& html);
+
+/** Lemma hinted by an inflection stub ("returning" → "return"), or empty when the entry isn't one. */
+std::string lemmaFromDefinition(const std::string& html);

--- a/src/dictionary/DictionaryRegistry.cpp
+++ b/src/dictionary/DictionaryRegistry.cpp
@@ -1,0 +1,563 @@
+#include "dictionary/DictionaryRegistry.h"
+
+#include <SDCardManager.h>
+#include <Serialization.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+
+#include "util/StringUtils.h"
+
+namespace {
+constexpr char kOverridesPath[] = "/.system/dict_langs.bin";
+
+std::string toLowerAscii(std::string s) {
+  for (char& c : s) {
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  return s;
+}
+
+std::string readIfoKey(const std::string& folderPath, const char* key) {
+  FsFile dir = SdMan.open(folderPath.c_str());
+  if (!dir || !dir.isDirectory()) {
+    if (dir) {
+      dir.close();
+    }
+    return "";
+  }
+  std::string ifoPath;
+  for (FsFile file = dir.openNextFile(); file; file = dir.openNextFile()) {
+    if (!file.isDirectory()) {
+      char name[160] = {};
+      file.getName(name, sizeof(name));
+      if (name[0] != '.' && StringUtils::checkFileExtension(std::string(name), ".ifo")) {
+        ifoPath = folderPath + "/" + name;
+      }
+    }
+    file.close();
+    if (!ifoPath.empty()) {
+      break;
+    }
+  }
+  dir.close();
+  if (ifoPath.empty()) {
+    return "";
+  }
+
+  const String contents = SdMan.readFile(ifoPath.c_str());
+  if (contents.isEmpty()) {
+    return "";
+  }
+  const std::string prefix = std::string(key) + "=";
+  int lineStart = 0;
+  const int len = contents.length();
+  while (lineStart < len) {
+    int lineEnd = contents.indexOf('\n', lineStart);
+    if (lineEnd < 0) {
+      lineEnd = len;
+    }
+    String line = contents.substring(lineStart, lineEnd);
+    line.trim();
+    lineStart = lineEnd + 1;
+    if (line.startsWith(prefix.c_str())) {
+      String value = line.substring(static_cast<int>(prefix.size()));
+      value.trim();
+      return value.c_str();
+    }
+  }
+  return "";
+}
+
+struct Override {
+  std::string folder;
+  std::string lang;
+};
+
+std::vector<Override> loadOverrides() {
+  std::vector<Override> out;
+  FsFile file;
+  if (!SdMan.openFileForRead("DICT", kOverridesPath, file)) {
+    return out;
+  }
+  uint8_t count = 0;
+  serialization::readPod(file, count);
+  for (uint8_t i = 0; i < count && i < 16; ++i) {
+    Override row;
+    serialization::readString(file, row.folder);
+    serialization::readString(file, row.lang);
+    if (!row.folder.empty()) {
+      out.push_back(std::move(row));
+    }
+  }
+  file.close();
+  return out;
+}
+
+void saveOverrides(const std::vector<Override>& rows) {
+  SdMan.mkdir("/.system");
+  FsFile file;
+  if (!SdMan.openFileForWrite("DICT", kOverridesPath, file)) {
+    return;
+  }
+  const uint8_t count = static_cast<uint8_t>(std::min<size_t>(rows.size(), 16));
+  serialization::writePod(file, count);
+  for (uint8_t i = 0; i < count; ++i) {
+    serialization::writeString(file, rows[i].folder);
+    serialization::writeString(file, rows[i].lang);
+  }
+  file.close();
+}
+}  // namespace
+
+const char* const DictionaryRegistry::kLangCycle[] = {"", "nl", "en", "fr", "la"};
+
+std::string DictionaryRegistry::primaryLanguageTag(const std::string& bcp47) {
+  std::string tag = toLowerAscii(bcp47);
+  while (!tag.empty() && (tag.front() == ' ' || tag.front() == '"')) {
+    tag.erase(tag.begin());
+  }
+  const size_t cut = tag.find_first_of("-_ .;/");
+  if (cut != std::string::npos) {
+    tag.resize(cut);
+  }
+  if (tag == "dut" || tag == "nld") {
+    return "nl";
+  }
+  if (tag == "eng") {
+    return "en";
+  }
+  if (tag == "fra" || tag == "fre") {
+    return "fr";
+  }
+  if (tag == "lat" || tag == "la") {
+    return "la";
+  }
+  return tag;
+}
+
+std::string DictionaryRegistry::inferLangFromName(const std::string& name) {
+  const std::string lower = toLowerAscii(name);
+  // Latin before Dutch: "latijn-nederlands" contains "neder".
+  if (lower.find("latin") != std::string::npos || lower.find("latijn") != std::string::npos ||
+      lower.find("la-") == 0 || lower == "la" || lower.find("la_") != std::string::npos) {
+    return "la";
+  }
+  if (lower.find("dutch") != std::string::npos || lower.find("neder") != std::string::npos ||
+      lower.find("nl-") == 0 || lower == "nl" || lower.find("nl_") != std::string::npos) {
+    return "nl";
+  }
+  if (lower.find("french") != std::string::npos || lower.find("franc") != std::string::npos ||
+      lower.find("fr-") == 0 || lower == "fr" || lower.find("fr_") != std::string::npos) {
+    return "fr";
+  }
+  if (lower.find("english") != std::string::npos || lower.find("oxford") != std::string::npos ||
+      lower.find("webster") != std::string::npos || lower.find("en-") == 0 || lower == "en" ||
+      lower.find("en_") != std::string::npos) {
+    return "en";
+  }
+  return "";
+}
+
+std::string DictionaryRegistry::langLabel(const std::string& lang) {
+  if (lang == "nl") {
+    return "Dutch";
+  }
+  if (lang == "en") {
+    return "English";
+  }
+  if (lang == "fr") {
+    return "French";
+  }
+  if (lang == "la") {
+    return "Latin";
+  }
+  if (lang.empty()) {
+    return "Auto";
+  }
+  return lang;
+}
+
+std::string DictionaryRegistry::displayLabel(const std::string& folder, const std::string& lang) {
+  if (folderIsBilingual(folder)) {
+    const std::string lower = toLowerAscii(folder);
+    const std::string src = langLabel(lower.substr(0, 2));
+    const std::string dst = langLabel(lower.substr(3, 2));
+    if (src != "Auto" && dst != "Auto") {
+      return src + " \xE2\x86\x92 " + dst;
+    }
+  }
+  const std::string fromLang = langLabel(primaryLanguageTag(lang));
+  if (!fromLang.empty() && fromLang != "Auto") {
+    return fromLang;
+  }
+  return langLabel(inferLangFromName(folder));
+}
+
+bool DictionaryRegistry::folderLooksLikeDictionary(const std::string& folderPath) {
+  FsFile dir = SdMan.open(folderPath.c_str());
+  if (!dir || !dir.isDirectory()) {
+    if (dir) {
+      dir.close();
+    }
+    return false;
+  }
+  bool hasIdx = false;
+  bool hasDict = false;
+  for (FsFile file = dir.openNextFile(); file; file = dir.openNextFile()) {
+    if (!file.isDirectory()) {
+      char name[160] = {};
+      file.getName(name, sizeof(name));
+      if (name[0] == '.') {
+        file.close();
+        continue;
+      }
+      if (StringUtils::checkFileExtension(std::string(name), ".idx")) {
+        hasIdx = true;
+      } else if (StringUtils::checkFileExtension(std::string(name), ".dict")) {
+        hasDict = true;
+      }
+    }
+    file.close();
+    if (hasIdx && hasDict) {
+      break;
+    }
+  }
+  dir.close();
+  return hasIdx && hasDict;
+}
+
+std::string DictionaryRegistry::readIfoLang(const std::string& folderPath) {
+  return primaryLanguageTag(readIfoKey(folderPath, "lang"));
+}
+
+std::string DictionaryRegistry::readIfoBookname(const std::string& folderPath) {
+  return readIfoKey(folderPath, "bookname");
+}
+
+std::vector<DictionaryRegistry::Entry> DictionaryRegistry::scan() {
+  std::vector<Entry> out;
+  FsFile dir = SdMan.open(kDictionariesRoot);
+  if (!dir || !dir.isDirectory()) {
+    if (dir) {
+      dir.close();
+    }
+    return out;
+  }
+  for (FsFile file = dir.openNextFile(); file; file = dir.openNextFile()) {
+    if (file.isDirectory()) {
+      char name[160] = {};
+      file.getName(name, sizeof(name));
+      const std::string folderPath = std::string(kDictionariesRoot) + "/" + name;
+      if (folderLooksLikeDictionary(folderPath)) {
+        Entry entry;
+        entry.folder = name;
+        const std::string override = overrideFor(name);
+        if (!override.empty()) {
+          entry.lang = override;
+        } else {
+          entry.lang = readIfoLang(folderPath);
+          if (entry.lang.empty()) {
+            entry.lang = inferLangFromName(name);
+          }
+        }
+        entry.bookname = readIfoBookname(folderPath);
+        entry.bilingual = folderIsBilingual(name);
+        out.push_back(std::move(entry));
+      }
+    }
+    file.close();
+  }
+  dir.close();
+  std::sort(out.begin(), out.end(), [](const Entry& a, const Entry& b) { return a.folder < b.folder; });
+  return out;
+}
+
+namespace {
+bool wordEquals(const std::string& word, const char* token) {
+  return word == token;
+}
+
+bool wordInList(const std::string& word, const char* const* list, const int n) {
+  for (int i = 0; i < n; ++i) {
+    if (wordEquals(word, list[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool containsUtf8(const std::string& word, const char* needle) {
+  return word.find(needle) != std::string::npos;
+}
+
+void scoreToken(const std::string& raw, const int weight, int& nl, int& en, int& fr, int& la) {
+  std::string word = toLowerAscii(raw);
+  if (word.empty()) {
+    return;
+  }
+
+  // Distinctive graphemes beat function-word overlap ("de"/"en"/"is" exist in multiple languages).
+  if (containsUtf8(word, "ij") || containsUtf8(word, "\xC4\xB3")) {  // ij / ĳ
+    nl += 5 * weight;
+  }
+  if (containsUtf8(word, "\xC3\xA7") || containsUtf8(word, "\xC5\x93") || containsUtf8(word, "\xC5\x92")) {  // ç œ Œ
+    fr += 5 * weight;
+  }
+  static const char* kFrMarks[] = {"\xC3\xA9", "\xC3\xA8", "\xC3\xAA", "\xC3\xA0", "\xC3\xA2",
+                                   "\xC3\xB9", "\xC3\xBB", "\xC3\xB4", "\xC3\xAE", "\xC3\xAF"};
+  for (const char* mark : kFrMarks) {
+    if (containsUtf8(word, mark)) {
+      fr += 2 * weight;
+      break;
+    }
+  }
+  static const char* kLaMarks[] = {"\xC4\x81", "\xC4\x93", "\xC4\xAB", "\xC5\x8D", "\xC5\xAB",
+                                   "\xC4\x80", "\xC4\x92", "\xC4\xAA", "\xC5\x8C", "\xC5\xAA"};  // āēīōū
+  for (const char* mark : kLaMarks) {
+    if (containsUtf8(word, mark)) {
+      la += 5 * weight;
+      break;
+    }
+  }
+  if (word.size() >= 4) {
+    const std::string tail4 = word.size() >= 4 ? word.substr(word.size() - 4) : word;
+    if (tail4 == "ibus" || tail4 == "orum" || tail4 == "arum" || tail4 == "ntur") {
+      la += 4 * weight;
+    }
+  }
+
+  static const char* kEnHi[] = {"the",   "and",  "of",    "with", "that",   "this", "from", "which",
+                                "would", "could", "should", "been", "were",  "they", "their", "have",
+                                "what",  "when", "not",   "was",  "for",    "but",  "his",  "her"};
+  static const char* kNlHi[] = {"het", "een", "niet", "ook", "nog",  "naar", "wordt", "geen",
+                                "jij", "ik",  "mijn", "maar", "zijn", "voor", "bij",   "uit",
+                                "als", "wel", "dit",  "deze", "haar", "hem",  "hij",   "wij"};
+  static const char* kFrHi[] = {"les",  "des",  "une",  "dans", "sont", "cette", "aux",  "elle",
+                                "vous", "avec", "qui",  "que",  "pas",  "pour",  "est",  "ces",
+                                "mon",  "ma",   "mes",  "son",  "ses",  "leur",  "sur",  "plus"};
+  static const char* kLaHi[] = {"sunt",  "erat",  "esse",  "tamen", "igitur", "enim",  "atque", "neque",
+                                "quidem", "nobis", "vobis", "mihi",  "eius",   "eorum", "quibus", "apud",
+                                "haec",  "quae",  "quod",  "sine",  "nam",    "ergo",  "sed",    "dum"};
+  static const char* kShared[] = {"de", "en", "is", "la", "un", "a", "in", "to", "du", "et", "le"};
+
+  if (wordInList(word, kEnHi, static_cast<int>(sizeof(kEnHi) / sizeof(kEnHi[0])))) {
+    en += 3 * weight;
+  }
+  if (wordInList(word, kNlHi, static_cast<int>(sizeof(kNlHi) / sizeof(kNlHi[0])))) {
+    nl += 3 * weight;
+  }
+  if (wordInList(word, kFrHi, static_cast<int>(sizeof(kFrHi) / sizeof(kFrHi[0])))) {
+    fr += 3 * weight;
+  }
+  if (wordInList(word, kLaHi, static_cast<int>(sizeof(kLaHi) / sizeof(kLaHi[0])))) {
+    la += 3 * weight;
+  }
+  if (wordInList(word, kShared, static_cast<int>(sizeof(kShared) / sizeof(kShared[0])))) {
+    // Shared closed-class words are almost useless alone; keep a whisper so a French "le/la/les"
+    // cluster can still beat English when accents are missing.
+    fr += 1 * weight;
+    nl += 1 * weight;
+  }
+}
+
+std::string folderMatchingLang(const std::vector<DictionaryRegistry::Entry>& entries, const std::string& lang) {
+  if (lang.empty()) {
+    return "";
+  }
+  std::string bilingual;
+  std::string mono;
+  for (const DictionaryRegistry::Entry& entry : entries) {
+    if (entry.lang != lang) {
+      continue;
+    }
+    if (entry.bilingual) {
+      if (bilingual.empty()) {
+        bilingual = entry.folder;
+      }
+    } else if (mono.empty()) {
+      mono = entry.folder;
+    }
+  }
+  return !bilingual.empty() ? bilingual : mono;
+}
+
+std::string folderMatchingName(const std::vector<DictionaryRegistry::Entry>& entries, const std::string& folder) {
+  if (folder.empty()) {
+    return "";
+  }
+  for (const DictionaryRegistry::Entry& entry : entries) {
+    if (entry.folder == folder) {
+      return entry.folder;
+    }
+  }
+  return "";
+}
+}  // namespace
+
+std::string DictionaryRegistry::detectLanguage(const std::vector<std::string>& words, const size_t focusIndex) {
+  int nl = 0;
+  int en = 0;
+  int fr = 0;
+  int la = 0;
+  for (size_t i = 0; i < words.size(); ++i) {
+    const int weight = (i == focusIndex) ? 2 : 1;
+    scoreToken(words[i], weight, nl, en, fr, la);
+  }
+
+  struct Scored {
+    const char* lang;
+    int score;
+  };
+  Scored ranked[] = {{"nl", nl}, {"en", en}, {"fr", fr}, {"la", la}};
+  std::sort(ranked, ranked + 4, [](const Scored& a, const Scored& b) { return a.score > b.score; });
+  // Need a real lead so mixed English prose with one French name doesn't flip the dictionary.
+  if (ranked[0].score >= 4 && ranked[0].score >= ranked[1].score + 2) {
+    return ranked[0].lang;
+  }
+  return "";
+}
+
+bool DictionaryRegistry::folderIsBilingual(const std::string& folder) {
+  const std::string lower = toLowerAscii(folder);
+  if (lower.size() < 5) {
+    return false;
+  }
+  const char sep = lower[2];
+  if (sep != '-' && sep != '_') {
+    return false;
+  }
+  if (!std::isalpha(static_cast<unsigned char>(lower[0])) || !std::isalpha(static_cast<unsigned char>(lower[1])) ||
+      !std::isalpha(static_cast<unsigned char>(lower[3])) || !std::isalpha(static_cast<unsigned char>(lower[4]))) {
+    return false;
+  }
+  if (lower.size() > 5 && std::isalpha(static_cast<unsigned char>(lower[5]))) {
+    return false;
+  }
+  return lower[0] != lower[3] || lower[1] != lower[4];
+}
+
+std::string DictionaryRegistry::folderForLanguage(const std::string& epubLanguage, const char* fallbackFolder) {
+  return folderForLookup("", "", epubLanguage, fallbackFolder);
+}
+
+std::string DictionaryRegistry::folderForLookup(const std::string& detectedLang, const std::string& sessionFolder,
+                                                const std::string& epubLanguage, const char* fallbackFolder) {
+  const auto entries = scan();
+  if (const std::string hit = folderMatchingLang(entries, primaryLanguageTag(detectedLang)); !hit.empty()) {
+    return hit;
+  }
+  if (const std::string hit = folderMatchingName(entries, sessionFolder); !hit.empty()) {
+    return hit;
+  }
+  if (const std::string hit = folderMatchingLang(entries, primaryLanguageTag(epubLanguage)); !hit.empty()) {
+    return hit;
+  }
+  if (fallbackFolder && fallbackFolder[0] != '\0') {
+    if (const std::string hit = folderMatchingName(entries, fallbackFolder); !hit.empty()) {
+      return hit;
+    }
+  }
+  if (!entries.empty()) {
+    return entries.front().folder;
+  }
+  return fallbackFolder ? std::string(fallbackFolder) : std::string();
+}
+
+std::vector<std::string> DictionaryRegistry::foldersInFallbackOrder(const std::string& preferredFolder) {
+  const auto entries = scan();
+  std::vector<std::string> out;
+  out.reserve(entries.size());
+  if (!preferredFolder.empty()) {
+    out.push_back(preferredFolder);
+  }
+  for (const Entry& entry : entries) {
+    if (entry.folder != preferredFolder) {
+      out.push_back(entry.folder);
+    }
+  }
+  return out;
+}
+
+std::vector<std::string> DictionaryRegistry::foldersForAutoLookup(const std::string& preferredFolder) {
+  const auto entries = scan();
+  std::string source;
+  bool preferredBilingual = false;
+  for (const Entry& entry : entries) {
+    if (entry.folder == preferredFolder) {
+      source = entry.lang;
+      preferredBilingual = entry.bilingual;
+      break;
+    }
+  }
+  if (source.empty()) {
+    source = inferLangFromName(preferredFolder);
+    preferredBilingual = folderIsBilingual(preferredFolder);
+  }
+
+  std::vector<std::string> bilingual;
+  std::vector<std::string> mono;
+  for (const Entry& entry : entries) {
+    if (entry.folder == preferredFolder || entry.lang != source) {
+      continue;
+    }
+    if (entry.bilingual) {
+      bilingual.push_back(entry.folder);
+    } else {
+      mono.push_back(entry.folder);
+    }
+  }
+
+  std::vector<std::string> out;
+  out.reserve(entries.size());
+  if (!preferredFolder.empty()) {
+    out.push_back(preferredFolder);
+  }
+  if (preferredBilingual) {
+    out.insert(out.end(), bilingual.begin(), bilingual.end());
+    out.insert(out.end(), mono.begin(), mono.end());
+  } else {
+    out.insert(out.end(), mono.begin(), mono.end());
+    out.insert(out.end(), bilingual.begin(), bilingual.end());
+  }
+  return out;
+}
+
+std::string DictionaryRegistry::overrideFor(const std::string& folder) {
+  for (const Override& row : loadOverrides()) {
+    if (row.folder == folder) {
+      return row.lang;
+    }
+  }
+  return "";
+}
+
+void DictionaryRegistry::setOverride(const std::string& folder, const std::string& lang) {
+  auto rows = loadOverrides();
+  bool found = false;
+  for (Override& row : rows) {
+    if (row.folder == folder) {
+      row.lang = lang;
+      found = true;
+      break;
+    }
+  }
+  if (!found && !lang.empty()) {
+    rows.push_back(Override{folder, lang});
+  }
+  if (lang.empty()) {
+    rows.erase(std::remove_if(rows.begin(), rows.end(), [&](const Override& row) { return row.folder == folder; }),
+               rows.end());
+  }
+  saveOverrides(rows);
+}
+
+int DictionaryRegistry::langCycleIndex(const std::string& lang) {
+  for (int i = 0; i < kLangCycleCount; ++i) {
+    if (lang == kLangCycle[i]) {
+      return i;
+    }
+  }
+  return 0;
+}

--- a/src/dictionary/DictionaryRegistry.h
+++ b/src/dictionary/DictionaryRegistry.h
@@ -1,0 +1,69 @@
+#pragma once
+
+/**
+ * @file DictionaryRegistry.h
+ * @brief Discovers StarDict folders under /dictionaries and maps them to language tags.
+ *
+ * Language comes from, in order: a persisted override, the .ifo `lang=` field, then the folder name.
+ * Only one dictionary is kept open at a time by StarDictLookup; this registry is metadata only.
+ */
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+class DictionaryRegistry {
+ public:
+  struct Entry {
+    std::string folder;
+    std::string lang;  // source language of headwords (en for both English/ and en-nl/)
+    std::string bookname;
+    bool bilingual = false;  // folder name is xx-yy with different source/target (en-nl, fr-nl, la-nl)
+  };
+
+  static constexpr const char* kDictionariesRoot = "/dictionaries";
+
+  static std::string primaryLanguageTag(const std::string& bcp47);
+  static std::string inferLangFromName(const std::string& name);
+  static std::string langLabel(const std::string& lang);
+  /** "English → Dutch" for en-nl, "Latin" / "English" for monolingual folders. */
+  static std::string displayLabel(const std::string& folder, const std::string& lang);
+  static bool folderLooksLikeDictionary(const std::string& folderPath);
+  static std::string readIfoLang(const std::string& folderPath);
+  static std::string readIfoBookname(const std::string& folderPath);
+
+  static std::vector<Entry> scan();
+  static std::string folderForLanguage(const std::string& epubLanguage, const char* fallbackFolder);
+  /**
+   * Picks a dictionary folder for a lookup. Order: confident passage language, then the session's
+   * last-used folder, then the EPUB's language, then the settings fallback. Book language is a weak
+   * prior on purpose — mixed books (Ulysses, etc.) need the surrounding words, not dc:language.
+   */
+  static std::string folderForLookup(const std::string& detectedLang, const std::string& sessionFolder,
+                                     const std::string& epubLanguage, const char* fallbackFolder);
+  static std::vector<std::string> foldersInFallbackOrder(const std::string& preferredFolder);
+  /**
+   * Auto-lookup order: the preferred folder, then other dictionaries of the same source language
+   * (translation dicts before monolingual). Does not open unrelated languages — cycling Left/Right
+   * still uses foldersInFallbackOrder for that.
+   */
+  static std::vector<std::string> foldersForAutoLookup(const std::string& preferredFolder);
+  /** True when @p folder looks like a bilingual pair (en-nl, fr_nl). */
+  static bool folderIsBilingual(const std::string& folder);
+
+  /**
+   * Scores a window of nearby words (Dutch / English / French / Latin). Returns "nl", "en", "fr",
+   * "la", or empty when the signal is too weak to override the session/book fallback. @p focusIndex
+   * is the looked-up word inside @p words.
+   */
+  static std::string detectLanguage(const std::vector<std::string>& words, size_t focusIndex);
+
+  static std::string overrideFor(const std::string& folder);
+  static void setOverride(const std::string& folder, const std::string& lang);
+
+  static const char* const kLangCycle[];
+  static constexpr int kLangCycleCount = 5;
+  static int langCycleIndex(const std::string& lang);
+};
+
+#define DICT_REGISTRY DictionaryRegistry

--- a/src/dictionary/StarDictLookup.cpp
+++ b/src/dictionary/StarDictLookup.cpp
@@ -36,63 +36,159 @@ bool isGeneralPunctuationAt(const unsigned char* b, const size_t i, const size_t
   return i + 2 < end && b[i] == 0xE2 && (b[i + 1] == 0x80 || b[i + 1] == 0x81);
 }
 
-/** Generates candidate base forms for a possibly-inflected English word (possessive, plural,
- *  past tense -ed, gerund -ing), so a form absent from the dictionary (e.g. "running", "jumped",
- *  "books") can still resolve to its base entry ("run", "jump", "book"). Heuristic suffix-stripping,
- *  not a full stemmer - callers try each candidate as an exact lookup and take the first hit, so
- *  over-generating (a few wrong candidates) is harmless as long as the right one is in the list. */
+/** Generates candidate base forms for a possibly-inflected word so a form absent from the
+ *  dictionary can still resolve to its lemma. Heuristic suffix-stripping, not a full stemmer —
+ *  callers try each candidate as an exact lookup and take the first hit. */
 std::vector<std::string> stemCandidates(const std::string& lower) {
   std::vector<std::string> out;
-  const size_t n = lower.size();
   auto add = [&](const std::string& s) {
     if (s.size() >= 2) {
       out.push_back(s);
     }
   };
 
-  if (n > 2 && lower[n - 2] == '\'' && lower[n - 1] == 's') {
-    add(lower.substr(0, n - 2));
-  }
-  if (n > 4 && lower.compare(n - 4, 4, "\xE2\x80\x99s") == 0) {
-    add(lower.substr(0, n - 4));
-  }
-
-  if (n > 4 && lower.compare(n - 3, 3, "ing") == 0) {
-    const std::string base = lower.substr(0, n - 3);
-    add(base);
-    add(base + "e");
-    if (base.size() >= 3 && base[base.size() - 1] == base[base.size() - 2]) {
-      add(base.substr(0, base.size() - 1));
+  auto stripClitic = [](const std::string& word) -> std::string {
+    auto starts = [&](const char* prefix) {
+      const size_t n = std::strlen(prefix);
+      return word.size() > n + 1 && word.compare(0, n, prefix) == 0 &&
+             std::isalpha(static_cast<unsigned char>(word[n])) != 0;
+    };
+    static const char* kAscii[] = {"l'", "d'", "n'", "m'", "t'", "s'", "c'", "j'", "qu'"};
+    for (const char* prefix : kAscii) {
+      if (starts(prefix)) {
+        return word.substr(std::strlen(prefix));
+      }
     }
-  }
-
-  if (n > 3 && lower.compare(n - 3, 3, "ied") == 0) {
-    add(lower.substr(0, n - 3) + "y");
-  }
-
-  if (n > 3 && lower.compare(n - 2, 2, "ed") == 0) {
-    const std::string base = lower.substr(0, n - 2);
-    add(base);
-    add(base + "e");
-    if (base.size() >= 3 && base[base.size() - 1] == base[base.size() - 2]) {
-      add(base.substr(0, base.size() - 1));
+    constexpr const char* kCurly = "\xE2\x80\x99";  // ’
+    if (word.size() > 5 && word.compare(1, 3, kCurly) == 0 &&
+        std::isalpha(static_cast<unsigned char>(word[0])) != 0) {
+      return word.substr(4);
     }
+    if (word.size() > 6 && word.compare(0, 2, "qu") == 0 && word.compare(2, 3, kCurly) == 0) {
+      return word.substr(5);
+    }
+    return "";
+  };
+
+  const std::string declitic = stripClitic(lower);
+  if (!declitic.empty()) {
+    add(declitic);
   }
 
-  if (n > 4 && lower.compare(n - 3, 3, "ies") == 0) {
-    add(lower.substr(0, n - 3) + "y");
-  }
+  auto addEnglish = [&](const std::string& form) {
+    const size_t n = form.size();
+    if (n > 2 && form[n - 2] == '\'' && form[n - 1] == 's') {
+      add(form.substr(0, n - 2));
+    }
+    if (n > 4 && form.compare(n - 4, 4, "\xE2\x80\x99s") == 0) {
+      add(form.substr(0, n - 4));
+    }
+    if (n > 4 && form.compare(n - 3, 3, "ing") == 0) {
+      const std::string base = form.substr(0, n - 3);
+      add(base);
+      add(base + "e");
+      if (base.size() >= 3 && base[base.size() - 1] == base[base.size() - 2]) {
+        add(base.substr(0, base.size() - 1));
+      }
+    }
+    if (n > 3 && form.compare(n - 3, 3, "ied") == 0) {
+      add(form.substr(0, n - 3) + "y");
+    }
+    if (n > 3 && form.compare(n - 2, 2, "ed") == 0) {
+      const std::string base = form.substr(0, n - 2);
+      add(base);
+      add(base + "e");
+      if (base.size() >= 3 && base[base.size() - 1] == base[base.size() - 2]) {
+        add(base.substr(0, base.size() - 1));
+      }
+    }
+    if (n > 4 && form.compare(n - 3, 3, "ies") == 0) {
+      add(form.substr(0, n - 3) + "y");
+    }
+    if (n > 3 && form.compare(n - 2, 2, "es") == 0) {
+      add(form.substr(0, n - 2));
+    }
+    if (n > 2 && form[n - 1] == 's' && form[n - 2] != 's') {
+      add(form.substr(0, n - 1));
+    }
+  };
 
-  if (n > 3 && lower.compare(n - 2, 2, "es") == 0) {
-    add(lower.substr(0, n - 2));
-  }
+  auto addFrench = [&](const std::string& form) {
+    const size_t n = form.size();
+    if (n > 6 && form.compare(n - 4, 4, "euse") == 0) {
+      add(form.substr(0, n - 4) + "eur");
+      add(form.substr(0, n - 4) + "er");
+    }
+    if (n > 5 && form.compare(n - 3, 3, "eur") == 0) {
+      add(form.substr(0, n - 3) + "er");
+    }
+    if (n > 5 && form.compare(n - 3, 3, "ent") == 0) {
+      add(form.substr(0, n - 3) + "er");
+    }
+    if (n > 5 && form.compare(n - 3, 3, "ons") == 0) {
+      add(form.substr(0, n - 3) + "er");
+    }
+    if (n > 5 && form.compare(n - 3, 3, "ant") == 0) {
+      add(form.substr(0, n - 3) + "er");
+    }
+    if (n > 4 && form.compare(n - 2, 2, "ez") == 0) {
+      add(form.substr(0, n - 2) + "er");
+    }
+    if (n > 4 && form.compare(n - 2, 2, "es") == 0) {
+      add(form.substr(0, n - 2) + "er");
+    }
+    if (n > 4 && form.compare(n - 2, 2, "\xC3\xA9") == 0) {  // é
+      add(form.substr(0, n - 2) + "er");
+    }
+    if (n > 5 && form.compare(n - 3, 3, "\xC3\xA9" "s") == 0) {  // és
+      add(form.substr(0, n - 3) + "er");
+    }
+    if (n > 5 && form.compare(n - 3, 3, "\xC3\xA9" "e") == 0) {  // ée
+      add(form.substr(0, n - 3) + "er");
+    }
+    if (n > 6 && form.compare(n - 4, 4, "\xC3\xA9" "es") == 0) {  // ées
+      add(form.substr(0, n - 4) + "er");
+    }
+  };
 
-  if (n > 2 && lower[n - 1] == 's' && lower[n - 2] != 's') {
-    add(lower.substr(0, n - 1));
+  auto addLatin = [&](const std::string& form) {
+    const size_t n = form.size();
+    if (n > 6) {
+      const std::string tail4 = form.substr(n - 4);
+      if (tail4 == "ibus" || tail4 == "orum" || tail4 == "arum" || tail4 == "orum") {
+        add(form.substr(0, n - 4));
+        add(form.substr(0, n - 2));
+      }
+    }
+    if (n > 4) {
+      const std::string tail2 = form.substr(n - 2);
+      if (tail2 == "us" || tail2 == "um" || tail2 == "ae" || tail2 == "is" || tail2 == "am" ||
+          tail2 == "os" || tail2 == "as") {
+        add(form.substr(0, n - 2));
+      }
+    }
+  };
+
+  addEnglish(lower);
+  addFrench(lower);
+  addLatin(lower);
+  if (!declitic.empty()) {
+    addEnglish(declitic);
+    addFrench(declitic);
+    addLatin(declitic);
   }
 
   return out;
 }
+
+}  // namespace
+
+std::vector<std::string> StarDictLookup::alternateForms(const std::string& queryWord) {
+  const std::string cleaned = stripSurroundingPunctuation(queryWord);
+  return stemCandidates(toLowerCopy(cleaned));
+}
+
+namespace {
 
 void pushUnique(std::vector<std::string>& list, const std::string& s) {
   if (s.empty()) {
@@ -246,6 +342,7 @@ void StarDictLookup::close() {
   std::vector<DefCacheEntry>().swap(defCache_);
   std::string().swap(folderPath_);
   std::string().swap(bookname_);
+  std::string().swap(lang_);
   std::string().swap(sameTypeSequence_);
   wordCount_ = 0;
   idxFileSize_ = 0;
@@ -281,6 +378,8 @@ bool StarDictLookup::parseIfo(const std::string& ifoPath) {
 
     if (key == "bookname") {
       bookname_ = value.c_str();
+    } else if (key == "lang") {
+      lang_ = value.c_str();
     } else if (key == "wordcount") {
       wordCount_ = static_cast<uint32_t>(value.toInt());
     } else if (key == "idxfilesize") {

--- a/src/dictionary/StarDictLookup.h
+++ b/src/dictionary/StarDictLookup.h
@@ -7,8 +7,8 @@
  * Only uncompressed .dict files are supported (no .dict.dz). Only the common
  * "sametypesequence" .ifo layout is supported, where each .idx entry's dict-file bytes are the
  * raw definition with no per-entry type prefix - this covers the vast majority of distributed
- * StarDict dictionaries. .syn synonym files are not consulted; lookups are exact/case-insensitive
- * word match plus a small English stem fallback.
+ * StarDict dictionaries. Optional uncompressed .syn files are not required; lookups try the
+ * typed word, then elision (l'/d'/…), then a small English / French / Latin stem fallback.
  *
  * Lookup index (same idea as CrossPoint 1.5's .qidx):
  * - A sidecar of uint32 .idx byte offsets, one sample every 256 entries.
@@ -24,7 +24,6 @@
 
 #include <cstdint>
 #include <string>
-#include <utility>
 #include <vector>
 
 class StarDictLookup {
@@ -42,6 +41,7 @@ class StarDictLookup {
   bool isOpen() const { return isOpen_; }
 
   const std::string& bookname() const { return bookname_; }
+  const std::string& lang() const { return lang_; }
   /** Absolute path of the folder that was last successfully opened (empty if closed). */
   const std::string& folderPath() const { return folderPath_; }
 
@@ -65,6 +65,9 @@ class StarDictLookup {
    *  outDefinition (capped to kMaxDefinitionBytes raw bytes) on success. If outTruncated is non-null,
    *  set to whether the on-disk definition was larger than the cap. */
   bool lookup(const std::string& queryWord, std::string& outDefinition, bool* outTruncated = nullptr);
+
+  /** Elision-stripped and suffix-stripped forms of @p queryWord, not including the word itself. */
+  static std::vector<std::string> alternateForms(const std::string& queryWord);
 
  private:
   struct DefCacheEntry {
@@ -126,6 +129,7 @@ class StarDictLookup {
   FsFile dictFile_;
   std::string folderPath_;
   std::string bookname_;
+  std::string lang_;
   std::string sameTypeSequence_;
   uint32_t wordCount_ = 0;
   uint32_t idxFileSize_ = 0;

--- a/src/network/LocalServer.cpp
+++ b/src/network/LocalServer.cpp
@@ -19,12 +19,14 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <functional>
 #include <set>
 
 #include "../state/ReaderSetting.h"
+#include "../state/SavedDictionaryWords.h"
 #include "../state/SystemSetting.h"
 #ifndef INX_SIMULATOR_WEB_ONLY
 #include "activity/reader/Epub/EpubActivity.h"
@@ -673,6 +675,8 @@ void LocalServer::begin() {
   server->on("/api/device-identity/card", HTTP_GET, [this] { handleDeviceIdentityCardImage(); });
   server->on("/api/files", HTTP_GET, [this] { handleFileListData(); });
   server->on("/api/export-notes", HTTP_GET, [this] { handleExportNotesData(); });
+  server->on("/api/dictionary-words", HTTP_GET, [this] { handleDictionaryWordsData(); });
+  server->on("/api/dictionary-words.csv", HTTP_GET, [this] { handleDictionaryWordsCsv(); });
   server->on("/api/book-tags", HTTP_GET, [this] { handleBookTagsGet(); });
   server->on("/api/book-tags", HTTP_POST, [this] { handleBookTagsPost(); });
   server->on("/api/library-index/refresh", HTTP_POST, [this] { handleLibraryIndexRefresh(); });
@@ -1112,6 +1116,119 @@ void LocalServer::handleExportNotesData() const {
     yield();
   }
   index.close();
+  server->sendContent("");
+#endif
+}
+
+namespace {
+std::string dictHtmlToPlain(const std::string& html) {
+  std::string out;
+  out.reserve(html.size());
+  bool inTag = false;
+  for (const unsigned char c : html) {
+    if (c == '<') {
+      inTag = true;
+      continue;
+    }
+    if (c == '>') {
+      inTag = false;
+      if (!out.empty() && out.back() != ' ') {
+        out.push_back(' ');
+      }
+      continue;
+    }
+    if (inTag) {
+      continue;
+    }
+    if (c == '\r' || c == '\n' || c == '\t') {
+      if (!out.empty() && out.back() != ' ') {
+        out.push_back(' ');
+      }
+    } else {
+      out.push_back(static_cast<char>(c));
+    }
+  }
+  std::string decoded;
+  decoded.reserve(out.size());
+  for (size_t i = 0; i < out.size(); ++i) {
+    if (out[i] == '&') {
+      if (out.compare(i, 5, "&amp;") == 0) {
+        decoded.push_back('&');
+        i += 4;
+        continue;
+      }
+      if (out.compare(i, 4, "&lt;") == 0) {
+        decoded.push_back('<');
+        i += 3;
+        continue;
+      }
+      if (out.compare(i, 4, "&gt;") == 0) {
+        decoded.push_back('>');
+        i += 3;
+        continue;
+      }
+      if (out.compare(i, 6, "&nbsp;") == 0) {
+        decoded.push_back(' ');
+        i += 5;
+        continue;
+      }
+      if (out.compare(i, 6, "&quot;") == 0) {
+        decoded.push_back('"');
+        i += 5;
+        continue;
+      }
+    }
+    decoded.push_back(out[i]);
+  }
+  while (!decoded.empty() && decoded.back() == ' ') {
+    decoded.pop_back();
+  }
+  return decoded;
+}
+
+std::string csvQuote(const std::string& field) {
+  std::string out = "\"";
+  for (const char c : field) {
+    if (c == '"') {
+      out += "\"\"";
+    } else if (c != '\r') {
+      out.push_back(c);
+    }
+  }
+  out += '"';
+  return out;
+}
+}  // namespace
+
+void LocalServer::handleDictionaryWordsData() const {
+#ifdef INX_SIMULATOR_WEB_ONLY
+  server->send(200, "application/json", "{\"ok\":true,\"count\":0}");
+#else
+  const int n = SAVED_WORDS.count();
+  char buf[64];
+  snprintf(buf, sizeof(buf), "{\"ok\":true,\"count\":%d}", n);
+  server->send(200, "application/json", buf);
+#endif
+}
+
+void LocalServer::handleDictionaryWordsCsv() const {
+#ifdef INX_SIMULATOR_WEB_ONLY
+  server->sendHeader("Content-Disposition", "attachment; filename=\"inx-vocabulary.csv\"");
+  server->send(200, "text/csv; charset=utf-8", "word,definition,language\n");
+#else
+  server->sendHeader("Content-Disposition", "attachment; filename=\"inx-vocabulary.csv\"");
+  server->setContentLength(CONTENT_LENGTH_UNKNOWN);
+  server->send(200, "text/csv; charset=utf-8", "");
+  server->sendContent("word,definition,language\n");
+  const int n = SAVED_WORDS.count();
+  for (int i = 0; i < n; ++i) {
+    const std::string word = SAVED_WORDS.wordAt(i);
+    const std::string definition = dictHtmlToPlain(SAVED_WORDS.definitionAt(i));
+    const std::string language = SAVED_WORDS.languageAt(i);
+    std::string row = csvQuote(word) + "," + csvQuote(definition) + "," + csvQuote(language) + "\n";
+    server->sendContent(row.c_str());
+    yield();
+  }
   server->sendContent("");
 #endif
 }

--- a/src/network/LocalServer.h
+++ b/src/network/LocalServer.h
@@ -84,6 +84,8 @@ class LocalServer {
   void handleExportPage() const;
   void handleFileListData() const;
   void handleExportNotesData() const;
+  void handleDictionaryWordsData() const;
+  void handleDictionaryWordsCsv() const;
   void handleDownload() const;
   void handleUpload() const;
   void handleUploadPost() const;

--- a/src/state/SavedDictionaryWords.cpp
+++ b/src/state/SavedDictionaryWords.cpp
@@ -125,6 +125,45 @@ std::string SavedDictionaryWordStore::definitionAt(int index) {
   return definition;
 }
 
+std::string SavedDictionaryWordStore::languageAt(int index) {
+  load();
+  if (index < 0 || index >= static_cast<int>(entries_.size())) {
+    return "";
+  }
+  const std::string path = std::string(kDir) + "/" + entries_[index].filename;
+  FsFile f;
+  if (!SdMan.openFileForRead("SDW", path, f)) {
+    return "";
+  }
+  uint8_t wordLen = 0;
+  if (f.read(&wordLen, sizeof(wordLen)) != sizeof(wordLen) || f.seekCur(wordLen) == false) {
+    f.close();
+    return "";
+  }
+  uint16_t defLen = 0;
+  if (f.read(&defLen, sizeof(defLen)) != sizeof(defLen) || f.seekCur(defLen) == false) {
+    f.close();
+    return "";
+  }
+  uint8_t langLen = 0;
+  if (f.read(&langLen, sizeof(langLen)) != sizeof(langLen)) {
+    f.close();
+    return "";
+  }
+  char buf[16] = {0};
+  const uint8_t readLen = std::min<uint8_t>(langLen, 15);
+  if (readLen > 0 && f.read(buf, readLen) != readLen) {
+    f.close();
+    return "";
+  }
+  if (langLen > readLen) {
+    f.seekCur(langLen - readLen);
+  }
+  f.close();
+  buf[readLen] = '\0';
+  return buf;
+}
+
 bool SavedDictionaryWordStore::contains(const std::string& word) {
   load();
   const std::string lower = toLowerCopy(word);
@@ -132,7 +171,7 @@ bool SavedDictionaryWordStore::contains(const std::string& word) {
                      [&lower](const SavedWordEntry& e) { return toLowerCopy(e.word) == lower; });
 }
 
-bool SavedDictionaryWordStore::add(const std::string& word, const std::string& definition) {
+bool SavedDictionaryWordStore::add(const std::string& word, const std::string& definition, const std::string& language) {
   load();
   if (word.empty() || word.size() > kMaxWordLen) {
     return false;
@@ -154,11 +193,16 @@ bool SavedDictionaryWordStore::add(const std::string& word, const std::string& d
   }
   const uint8_t wordLen = static_cast<uint8_t>(std::min(word.size(), kMaxWordLen));
   const uint16_t defLen = static_cast<uint16_t>(std::min(definition.size(), kMaxDefinitionLen));
+  const uint8_t langLen = static_cast<uint8_t>(std::min(language.size(), static_cast<size_t>(15)));
   f.write(&wordLen, sizeof(wordLen));
   f.write(reinterpret_cast<const uint8_t*>(word.data()), wordLen);
   f.write(&defLen, sizeof(defLen));
   if (defLen > 0) {
     f.write(reinterpret_cast<const uint8_t*>(definition.data()), defLen);
+  }
+  f.write(&langLen, sizeof(langLen));
+  if (langLen > 0) {
+    f.write(reinterpret_cast<const uint8_t*>(language.data()), langLen);
   }
   f.close();
 

--- a/src/state/SavedDictionaryWords.h
+++ b/src/state/SavedDictionaryWords.h
@@ -35,13 +35,15 @@ class SavedDictionaryWordStore {
   std::string wordAt(int index);
   /** Reads the stored (already-HTML-formatted) definition for a saved word from disk. */
   std::string definitionAt(int index);
+  /** ISO language tag stored at save time (empty on older files). */
+  std::string languageAt(int index);
 
   /** Case-insensitive membership check. */
   bool contains(const std::string& word);
 
   /** Writes word+definition to disk immediately and adds it to the in-RAM list. Returns false if
    *  already saved (case-insensitive), at the capacity limit, or the write failed. */
-  bool add(const std::string& word, const std::string& definition);
+  bool add(const std::string& word, const std::string& definition, const std::string& language = "");
 
   /** Deletes a saved word's file and removes it from the in-RAM list (case-insensitive match).
    *  Returns false if no such word was saved. */


### PR DESCRIPTION
## Summary

- Several StarDict folders can live under `/dictionaries` at once. A lookup scores the surrounding sentence (Dutch, English, French, Latin) and opens that language first, instead of trusting only the EPUB's `dc:language`.
- Translation dictionaries are preferred; if the hit is only an inflection stub ("past participle of…", "voltooid deelwoord van…"), the lemma is tried, then a same-language defining dictionary. Left/Right still cycles every installed folder when the guess is wrong.
- Sync → Choose dictionaries assigns a source language when the folder name is not enough, and Confirm sets the fallback. Saved words keep a language tag, and `/api/dictionary-words.csv` exports word / definition / language for Anki.

HTML definitions also keep bold, italic, and headings so bilingual entries stay readable on the e-ink panel.

## Test plan

- [ ] Put at least two StarDict folders under `/dictionaries` (for example `en-nl` and `English`)
- [ ] Open a mixed-language book and look up a Dutch word in an English chapter — it should open the Dutch dictionary
- [ ] Look up an inflected English form that only has "past participle of X" — it should show the lemma's real gloss, or fall back to the English defining dictionary
- [ ] Left/Right on a definition should cycle every installed folder
- [ ] Sync → Choose dictionaries: Left/Right sets language, Confirm sets the fallback
- [ ] Save a word, then download `/api/dictionary-words.csv` and check the language column


Made with [Cursor](https://cursor.com)