### PR TITLE
feat: preload the next chapter while on a chapter's last page

### DIFF
--- a/src/activity/reader/Epub/EpubActivity.cpp
+++ b/src/activity/reader/Epub/EpubActivity.cpp
@@ -369,6 +369,84 @@ std::unique_ptr<Section> EpubActivity::loadSection(int spineIndex, const Viewpor
   return loadedSection;
 }
 
+bool EpubActivity::isSectionCached(int spineIndex, const ViewportInfo& info) {
+  if (!epub) return false;
+  std::shared_ptr<Epub> sharedEpub = std::shared_ptr<Epub>(epub.get(), [](Epub*) {});
+  auto probe = std::unique_ptr<Section>(new Section(sharedEpub, spineIndex, renderer));
+  return probe->loadSectionFile(info.fontId, info.lineCompression, info.wordSpacing,
+                                bookSettings.extraParagraphSpacing, bookSettings.paragraphAlignment, info.width,
+                                info.height, bookSettings.hyphenationEnabled,
+                                bookSettings.paragraphCssIndentEnabled != 0, bookSettings.bionicReadingEnabled != 0);
+}
+
+/**
+ * @brief Paginates a chapter into its cache file ahead of time, drawing nothing
+ *
+ * Only the section .bin is produced - the loaded Section object is thrown away. Turning the page then hits
+ * the cached-file path in loadSection() and skips the "Loading chapter..." popup entirely.
+ */
+void EpubActivity::preloadSection(int spineIndex) {
+  if (!epub) return;
+  const int totalSpines = epub->getSpineItemsCount();
+  if (spineIndex < 0 || spineIndex >= totalSpines) return;
+
+  ViewportInfo info = calculateViewport();
+  if (isSectionCached(spineIndex, info)) {
+    lastPreloadedSpineIndex = spineIndex;
+    return;
+  }
+
+  Serial.printf("[%lu] [EPA] preloadSection: building spine=%d in background\n", millis(), spineIndex);
+  // showProgress=false: nothing is drawn, so the page the reader is looking at stays untouched.
+  const bool ok = buildSection(spineIndex, info, false, false);
+  // Mark it either way - a spine that fails to build would fail on every retry too, and re-trying it on
+  // every idle frame would make the last page of the chapter permanently unresponsive.
+  lastPreloadedSpineIndex = spineIndex;
+  if (!ok) {
+    Serial.printf("[%lu] [EPA] preloadSection: build failed spine=%d\n", millis(), spineIndex);
+  }
+}
+
+/**
+ * @brief Queues the next chapter for preloading when the reader lands on the last page of this one
+ */
+void EpubActivity::schedulePreloadIfOnLastPage() {
+  pendingPreloadSpine_ = -1;
+  if (!epub || !section || section->pageCount <= 0) return;
+  if (menuDrawerVisible || settingsDrawerVisible || annUi_.isActive() || dictUi_.isActive()) return;
+  if (section->currentPage != section->pageCount - 1) return;
+
+  const int nextSpine = currentSpineIndex + 1;
+  if (nextSpine >= epub->getSpineItemsCount()) return;
+  if (nextSpine == lastPreloadedSpineIndex) return;
+
+  pendingPreloadSpine_ = nextSpine;
+  preloadDueAt_ = millis() + kPreloadIdleDelayMs;
+}
+
+/**
+ * @brief Runs a queued chapter preload once the reader has been idle for a moment
+ *
+ * Pagination is blocking, so it is deliberately held off until nothing else is going on: any button
+ * activity pushes it back rather than making the device feel stuck right after a page turn.
+ */
+void EpubActivity::maybeRunPendingPreload() {
+  if (pendingPreloadSpine_ < 0) return;
+  if (menuDrawerVisible || settingsDrawerVisible || annUi_.isActive() || dictUi_.isActive() || isDoingSomethingHeavy) {
+    return;
+  }
+
+  if (mappedInput.wasAnyPressed() || mappedInput.wasAnyReleased()) {
+    preloadDueAt_ = millis() + kPreloadIdleDelayMs;
+    return;
+  }
+  if (static_cast<long>(millis() - preloadDueAt_) < 0) return;
+
+  const int spineIndex = pendingPreloadSpine_;
+  pendingPreloadSpine_ = -1;
+  preloadSection(spineIndex);
+}
+
 /**
  * @brief Sets up orientation based on book settings
  */
@@ -692,6 +770,8 @@ void EpubActivity::onEnter() {
   lastGoodSpineIndex_ = currentSpineIndex;
   lastGoodPageNumber_ = nextPageNumber;
   chapterRecoveryAttempted_ = false;
+  lastPreloadedSpineIndex = -1;
+  pendingPreloadSpine_ = -1;
 
   annUi_.clearSessionAndCapture();
 }
@@ -924,8 +1004,12 @@ void EpubActivity::loop() {
   if (updateRequired) {
     updateRequired = false;
     renderScreen();
+    schedulePreloadIfOnLastPage();
     return;
   }
+
+  // Nothing to handle this frame: a good moment to paginate the next chapter, if one is queued.
+  maybeRunPendingPreload();
 }
 
 /**
@@ -1540,6 +1624,7 @@ void EpubActivity::jumpToPercent(int percent) {
  * @param forward True for forward page turn, false for backward
  */
 void EpubActivity::pageTurn(bool forward) {
+  pendingPreloadSpine_ = -1;
   if (!epub) {
     updateRequired = true;
     return;
@@ -2218,6 +2303,9 @@ void EpubActivity::saveBookSettings() {
  */
 void EpubActivity::applyBookSettings() {
   dismissMenuDrawerForBlockingWork();
+  // Every cached section is about to be stale for the new layout; forget what was preloaded for the old one.
+  lastPreloadedSpineIndex = -1;
+  pendingPreloadSpine_ = -1;
 
   int currentPage = 0;
   int currentSpine = currentSpineIndex;

--- a/src/activity/reader/Epub/EpubActivity.cpp
+++ b/src/activity/reader/Epub/EpubActivity.cpp
@@ -412,7 +412,7 @@ void EpubActivity::preloadSection(int spineIndex) {
  */
 void EpubActivity::schedulePreloadIfOnLastPage() {
   pendingPreloadSpine_ = -1;
-  if (!epub || !section || section->pageCount <= 0) return;
+  if (!epub || !section || section->pageCount == 0) return;
   if (menuDrawerVisible || settingsDrawerVisible || annUi_.isActive() || dictUi_.isActive()) return;
   if (section->currentPage != section->pageCount - 1) return;
 

--- a/src/activity/reader/Epub/EpubActivity.h
+++ b/src/activity/reader/Epub/EpubActivity.h
@@ -127,6 +127,11 @@ class EpubActivity final : public ActivityWithSubactivity {
   std::vector<Bookmark> bookmarks;
   bool showBookmarkIndicator = false;
   int lastPreloadedSpineIndex = -1;
+  /** Spine queued for background pagination (next chapter, while sitting on the last page); -1 when idle. */
+  int pendingPreloadSpine_ = -1;
+  /** Earliest millis() at which the queued preload may run - keeps input snappy right after the page turn. */
+  unsigned long preloadDueAt_ = 0;
+  static constexpr unsigned long kPreloadIdleDelayMs = 400;
   bool lastPageHadImages = false;
   /** Previous page: image union bbox at least half screen in both dimensions (for smart HALF refresh). */
   bool lastPageHadLargeImage = false;
@@ -278,7 +283,20 @@ class EpubActivity final : public ActivityWithSubactivity {
 
   void displayBookTitle();
   void drawLoadingScreen();
-  void preloadNextSection();
+  /**
+   * Queues the next chapter for background pagination once the reader settles on the last page of the
+   * current one, so the "Loading chapter..." wait is already paid by the time they turn the page.
+   */
+  void schedulePreloadIfOnLastPage();
+
+  /** Runs a queued preload when the reader has been idle long enough; no-op otherwise. */
+  void maybeRunPendingPreload();
+
+  /** Paginates spineIndex into its cache file if it isn't already cached for the current layout. */
+  void preloadSection(int spineIndex);
+
+  /** True when spineIndex already has a section cache file matching the given layout. */
+  bool isSectionCached(int spineIndex, const ViewportInfo& info);
 
   /** Hides reader menu and settings drawers (if open). Optionally repaints the reader (skip during error popups). */
   void dismissMenuDrawerForBlockingWork(bool repaintReaderScreen = true);


### PR DESCRIPTION
This PR implements a feature I've been wanting for a bit, namely loading of the next chapter when paging to the final page of the previous one. Loading the next chapter takes a little bit, but almost never as long as reading the final page. This way, paging from one chapter to the next feels the same as paging within a chapter. If you click next page too fast, the loading chapter dialogue still opens as normal.

It does this by checking if you're on the last page, and if so building the next chapter and caching it.

I've tested it on my own X4, and it works as expected.


AI summary:
> ## Problem
> 
> Turning the page past the end of a chapter paginates the next spine right then, behind a "Loading chapter..." popup. On a longer chapter that is a noticeable wait, and it lands at the worst moment — mid-read, on a deliberate page turn.
> 
> The work itself is unavoidable, but its timing is not: as soon as the reader lands on the *last* page of a chapter, the device is idle and the next spine is already known.
> 
> ## Change
> 
> - `schedulePreloadIfOnLastPage()` runs after `renderScreen()` in `loop()`. On the last page of a chapter with a next spine available, it queues that spine with a short delay.
> - `maybeRunPendingPreload()` runs from `loop()`'s idle tail — only reached when no input, drawer, or overlay handled the frame. Any button press/release pushes the deadline back, so the blocking build never makes a page turn or Back feel stuck.
> - `preloadSection()` builds the section `.bin` with `showProgress=false`, so nothing is drawn and the page on screen is untouched. `loadSection()` then takes its cached path on the turn, with no popup at all.
> 
> Only the cache file is produced; the `Section` object is discarded, so there is no added steady-state RAM cost.
> 
> ### Correctness details
> 
> - `isSectionCached()` probes before building. `buildSection()` deletes an existing `.bin`, so it must never run over a good cache.
> - Failed builds are marked as attempted, so a spine that cannot build can't retry on every idle frame and wedge the last page.
> - Preload state resets in `onEnter`/`pageTurn`/`applyBookSettings`, and the probe re-checks the layout parameters, so a font, margin, or orientation change cannot serve a stale chapter.
> 
> ## Testing
> 
> - Builds clean on `-e default` on top of current `main`.
> - Verified on device: turning off the end of a chapter after a brief pause is now instant, with no loading popup.
> 
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)