### PR TITLE
Keep chapter openings on one page and count pages within the chapter

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -564,6 +564,10 @@ bool Epub::parseTocNavFile() const {
  * @return true if the book was successfully loaded, false otherwise
  */
 bool Epub::load(const bool buildIfMissing) {
+  tocPageLookupSpine_ = -1;
+  tocPageLookupPage_ = -1;
+  tocPageLookupCount_ = -1;
+  tocPageLookupIndex_ = -1;
   setupCacheDir();
 
   parsedCssParser_.reset();
@@ -1027,6 +1031,102 @@ int Epub::getSpineIndexForTocIndex(int tocIndex) const { return getTocItem(tocIn
  * @return Corresponding TOC index, or 0 if not found
  */
 int Epub::getTocIndexForSpineIndex(int spineIndex) const { return getSpineItem(spineIndex).tocIndex; }
+
+int Epub::getTocIndexForSpinePage(const int spineIndex, const int page, const int pageCount) const {
+  if (tocPageLookupSpine_ == spineIndex && tocPageLookupPage_ == page && tocPageLookupCount_ == pageCount) {
+    return tocPageLookupIndex_;
+  }
+
+  const int fallback = getTocIndexForSpineIndex(spineIndex);
+  const int tocCount = getTocItemsCount();
+  auto cacheAndReturn = [this, spineIndex, page, pageCount](const int index) {
+    tocPageLookupSpine_ = spineIndex;
+    tocPageLookupPage_ = page;
+    tocPageLookupCount_ = pageCount;
+    tocPageLookupIndex_ = index;
+    return index;
+  };
+  if (tocCount <= 0) {
+    return cacheAndReturn(fallback);
+  }
+
+  int lo = fallback;
+  if (lo < 0 || lo >= tocCount) {
+    lo = 0;
+  }
+  while (lo > 0) {
+    if (getTocItem(lo - 1).spineIndex != spineIndex) {
+      break;
+    }
+    --lo;
+  }
+
+  int maxLevel = 0;
+  int sameCount = 0;
+  int last = lo;
+  for (int i = lo; i < tocCount; ++i) {
+    const auto item = getTocItem(i);
+    if (item.spineIndex != spineIndex) {
+      if (sameCount > 0) {
+        break;
+      }
+      continue;
+    }
+    ++sameCount;
+    last = i;
+    if (static_cast<int>(item.level) > maxLevel) {
+      maxLevel = static_cast<int>(item.level);
+    }
+  }
+
+  if (sameCount == 0) {
+    if (fallback < 0 || fallback >= tocCount) {
+      return cacheAndReturn(fallback);
+    }
+    const auto inherited = getTocItem(fallback);
+    if (inherited.spineIndex >= spineIndex) {
+      return cacheAndReturn(fallback);
+    }
+    for (int i = fallback - 1; i >= 0; --i) {
+      if (getTocItem(i).level < inherited.level) {
+        return cacheAndReturn(i);
+      }
+    }
+    return cacheAndReturn(fallback);
+  }
+
+  int leafCount = 0;
+  int firstLeaf = lo;
+  for (int i = lo; i <= last; ++i) {
+    const auto item = getTocItem(i);
+    if (item.spineIndex != spineIndex) {
+      continue;
+    }
+    if (static_cast<int>(item.level) >= maxLevel) {
+      if (leafCount == 0) {
+        firstLeaf = i;
+      }
+      ++leafCount;
+    }
+  }
+  if (leafCount <= 1 || pageCount <= 0) {
+    return cacheAndReturn(leafCount == 0 ? lo : firstLeaf);
+  }
+
+  const int slot = std::min(leafCount - 1, std::max(0, page) * leafCount / std::max(1, pageCount));
+  int n = 0;
+  for (int i = lo; i <= last; ++i) {
+    const auto item = getTocItem(i);
+    if (item.spineIndex != spineIndex || static_cast<int>(item.level) < maxLevel) {
+      continue;
+    }
+    if (n == slot) {
+      return cacheAndReturn(i);
+    }
+    ++n;
+  }
+  return cacheAndReturn(firstLeaf);
+}
 
 /**
  * @brief Gets the cumulative size up to a specific spine item.

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -24,6 +24,10 @@ class Epub {
   std::unique_ptr<BookMetadataCache> bookMetadataCache;
   mutable std::unique_ptr<CssParser> parsedCssParser_;
   mutable bool parsedCssLoaded_ = false;
+  mutable int tocPageLookupSpine_ = -1;
+  mutable int tocPageLookupPage_ = -1;
+  mutable int tocPageLookupCount_ = -1;
+  mutable int tocPageLookupIndex_ = -1;
 
   bool findContentOpfFile(std::string* contentOpfFile) const;
   bool parseContentOpf(BookMetadataCache::BookMetadata& bookMetadata);
@@ -90,6 +94,8 @@ class Epub {
   BookMetadataCache::TocEntry getTocItem(int tocIndex) const;
   int getSpineIndexForTocIndex(int tocIndex) const;
   int getTocIndexForSpineIndex(int spineIndex) const;
+  /** TOC entry for this spine at @p page, preferring nested chapter titles over a wrapping part title. */
+  int getTocIndexForSpinePage(int spineIndex, int page, int pageCount) const;
   int getSpineIndexForTextReference() const;
   /** First spine suitable for reading when opening a book (guide text ref, else TOC, else first HTML spine). */
   int getSpineIndexForInitialOpen() const;

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -19,7 +19,7 @@
 #include "parsers/ChapterHtmlSlimParser.h"
 
 namespace {
-constexpr uint8_t SECTION_FILE_VERSION = 77;  // 77: chapter-opening layout + in-section chapter markers
+constexpr uint8_t SECTION_FILE_VERSION = 78;  // 78: keep chapter number + first body on the same page
 constexpr uint32_t HEADER_SIZE = sizeof(uint8_t) + sizeof(int) + sizeof(float) + sizeof(float) + sizeof(bool) +
                                  sizeof(uint8_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(bool) + sizeof(bool) +
                                  sizeof(bool) + sizeof(uint16_t) + sizeof(uint32_t);

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -10,6 +10,7 @@
 #include <SDCardManager.h>
 #include <Serialization.h>
 
+#include <algorithm>
 #include <exception>
 #include <new>
 
@@ -18,7 +19,7 @@
 #include "parsers/ChapterHtmlSlimParser.h"
 
 namespace {
-constexpr uint8_t SECTION_FILE_VERSION = 76;  // 76: natural-size CSS background HRs
+constexpr uint8_t SECTION_FILE_VERSION = 77;  // 77: chapter-opening layout + in-section chapter markers
 constexpr uint32_t HEADER_SIZE = sizeof(uint8_t) + sizeof(int) + sizeof(float) + sizeof(float) + sizeof(bool) +
                                  sizeof(uint8_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(bool) + sizeof(bool) +
                                  sizeof(bool) + sizeof(uint16_t) + sizeof(uint32_t);
@@ -111,6 +112,7 @@ bool Section::loadSectionFile(const int fontId, const float lineCompression, con
   }
   lutOffset = 0;
   pageOffsets.clear();
+  chapterMarkers.clear();
 
   if (!SdMan.openFileForRead("SCT", filePath, file)) return false;
 
@@ -178,15 +180,44 @@ bool Section::loadSectionFile(const int fontId, const float lineCompression, con
     return false;
   }
 
-  if (pageCount > 0 && pageCount <= MAX_CACHED_PAGE_OFFSETS && lutOffset > 0) {
-    try {
-      pageOffsets.resize(pageCount);
-      file.seek(lutOffset);
-      for (uint16_t i = 0; i < pageCount; ++i) {
-        serialization::readPod(file, pageOffsets[i]);
+  if (pageCount > 0 && lutOffset > 0) {
+    if (pageCount <= MAX_CACHED_PAGE_OFFSETS) {
+      try {
+        pageOffsets.resize(pageCount);
+        file.seek(lutOffset);
+        for (uint16_t i = 0; i < pageCount; ++i) {
+          serialization::readPod(file, pageOffsets[i]);
+        }
+      } catch (...) {
+        pageOffsets.clear();
+        file.seek(lutOffset + static_cast<uint32_t>(pageCount) * sizeof(uint32_t));
       }
-    } catch (...) {
-      pageOffsets.clear();
+    } else {
+      file.seek(lutOffset + static_cast<uint32_t>(pageCount) * sizeof(uint32_t));
+    }
+  }
+
+  chapterMarkers.clear();
+  uint16_t markerCount = 0;
+  if (file.available() >= static_cast<int>(sizeof(uint16_t))) {
+    serialization::readPod(file, markerCount);
+    if (markerCount > 128) {
+      markerCount = 0;
+    }
+    for (uint16_t i = 0; i < markerCount; ++i) {
+      ChapterMarker marker;
+      uint8_t titleLen = 0;
+      serialization::readPod(file, marker.startPage);
+      serialization::readPod(file, titleLen);
+      if (titleLen > 48) {
+        chapterMarkers.clear();
+        break;
+      }
+      if (titleLen > 0) {
+        marker.title.resize(titleLen);
+        file.read(reinterpret_cast<uint8_t*>(&marker.title[0]), titleLen);
+      }
+      chapterMarkers.push_back(std::move(marker));
     }
   }
 
@@ -454,6 +485,27 @@ bool Section::createSectionFile(const int fontId, const int headerFontId, const 
     serialization::writePod(file, pos);
   }
 
+  const auto& starts = visitor.chapterStarts();
+  uint16_t markerCount = static_cast<uint16_t>(std::min<size_t>(starts.size(), 128));
+  serialization::writePod(file, markerCount);
+  chapterMarkers.clear();
+  chapterMarkers.reserve(markerCount);
+  for (uint16_t i = 0; i < markerCount; ++i) {
+    ChapterMarker marker;
+    marker.startPage = starts[i].page;
+    marker.title = starts[i].title;
+    if (marker.title.size() > 48) {
+      marker.title.resize(48);
+    }
+    const uint8_t titleLen = static_cast<uint8_t>(marker.title.size());
+    serialization::writePod(file, marker.startPage);
+    serialization::writePod(file, titleLen);
+    if (titleLen > 0) {
+      file.write(reinterpret_cast<const uint8_t*>(marker.title.data()), titleLen);
+    }
+    chapterMarkers.push_back(std::move(marker));
+  }
+
   file.seek(HEADER_SIZE - sizeof(uint32_t) - sizeof(pageCount));
   serialization::writePod(file, pageCount);
   serialization::writePod(file, lutOffset);
@@ -506,6 +558,48 @@ std::unique_ptr<Page> Section::loadPageFromSectionFile() {
 bool Section::clearCache() const {
   if (SdMan.exists(filePath.c_str())) {
     return SdMan.remove(filePath.c_str());
+  }
+  return true;
+}
+
+const Section::ChapterMarker* Section::chapterMarkerForPage(const int page) const {
+  if (chapterMarkers.empty() || page < static_cast<int>(chapterMarkers.front().startPage)) {
+    return nullptr;
+  }
+  const Section::ChapterMarker* found = &chapterMarkers.front();
+  for (const auto& marker : chapterMarkers) {
+    if (static_cast<int>(marker.startPage) > page) {
+      break;
+    }
+    found = &marker;
+  }
+  return found;
+}
+
+bool Section::chapterRangeForPage(const int page, int* startOut, int* countOut) const {
+  if (chapterMarkers.size() < 2 || pageCount == 0) {
+    return false;
+  }
+  const ChapterMarker* marker = chapterMarkerForPage(page);
+  if (marker == nullptr) {
+    return false;
+  }
+  int start = static_cast<int>(marker->startPage);
+  int end = static_cast<int>(pageCount);
+  for (const auto& next : chapterMarkers) {
+    if (static_cast<int>(next.startPage) > start) {
+      end = static_cast<int>(next.startPage);
+      break;
+    }
+  }
+  if (end <= start) {
+    return false;
+  }
+  if (startOut) {
+    *startOut = start;
+  }
+  if (countOut) {
+    *countOut = end - start;
   }
   return true;
 }

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -57,6 +57,15 @@ class Section {
   uint16_t pageCount = 0;
   int currentPage = 0;
 
+  struct ChapterMarker {
+    uint16_t startPage = 0;
+    std::string title;
+  };
+  std::vector<ChapterMarker> chapterMarkers;
+
+  const ChapterMarker* chapterMarkerForPage(int page) const;
+  bool chapterRangeForPage(int page, int* startOut, int* countOut) const;
+
   /**
    * Constructs a new Section.
    *

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -387,32 +387,250 @@ std::string trimAsciiWhitespace(std::string value) {
   return std::string(first, last);
 }
 
-bool isSceneBreakMarker(const std::string& text, std::string* markerText) {
+enum class SceneBreakKind { None, Literary, Markup, PageBreak, ChapterHeading };
+
+bool isLiteraryBreakCp(const uint32_t cp) {
+  return cp == '.' || cp == '*' || cp == 0x2022 || cp == 0x00B7;
+}
+
+bool isMarkupBreakCp(const uint32_t cp) {
+  return cp == '=' || cp == '-' || cp == '_' || cp == '~' || cp == 0x2013 || cp == 0x2014;
+}
+
+bool isWordSeparatorCp(const uint32_t cp) {
+  if (cp == ' ' || cp == '\t' || cp == '\n' || cp == '\r' || cp == '\f' || cp == '\v') {
+    return true;
+  }
+  if (cp == 0x00A0 || cp == 0x202F || cp == 0x205F || cp == 0x3000) {
+    return true;
+  }
+  if (cp >= 0x2000 && cp <= 0x200A) {
+    return true;
+  }
+  if (cp == 0x200B || cp == 0x2060 || cp == 0xFEFF) {
+    return true;
+  }
+  return false;
+}
+
+bool codepointUsesJoiningScript(const uint32_t cp) {
+  if ((cp >= 0x1100 && cp <= 0x11FF) || (cp >= 0x3130 && cp <= 0x318F) || (cp >= 0xA960 && cp <= 0xA97F) ||
+      (cp >= 0xAC00 && cp <= 0xD7AF)) {
+    return true;
+  }
+  if ((cp >= 0x2E80 && cp <= 0x2FFF) || (cp >= 0x3040 && cp <= 0x30FF) || (cp >= 0x3100 && cp <= 0x312F) ||
+      (cp >= 0x31F0 && cp <= 0x31FF) || (cp >= 0x3400 && cp <= 0x4DBF) || (cp >= 0x4E00 && cp <= 0x9FFF) ||
+      (cp >= 0xF900 && cp <= 0xFAFF) || (cp >= 0x20000 && cp <= 0x2FA1F)) {
+    return true;
+  }
+  if ((cp >= 0x0E00 && cp <= 0x0E7F) || (cp >= 0x0E80 && cp <= 0x0EFF) || (cp >= 0x1000 && cp <= 0x109F) ||
+      (cp >= 0x1780 && cp <= 0x17FF)) {
+    return true;
+  }
+  return false;
+}
+
+bool tokenUsesJoiningScript(const char* s, const int len) {
+  if (s == nullptr || len <= 0) {
+    return false;
+  }
+  const unsigned char* p = reinterpret_cast<const unsigned char*>(s);
+  const unsigned char* const end = p + len;
+  while (p < end) {
+    if (codepointUsesJoiningScript(utf8NextCodepoint(&p))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+SceneBreakKind classifySceneBreak(const std::string& text) {
   const std::string trimmed = trimAsciiWhitespace(text);
   if (trimmed.empty()) {
-    return false;
+    return SceneBreakKind::None;
   }
 
   int markerCount = 0;
+  bool markup = false;
+  bool sawEquals = false;
+  bool sawOtherMarkup = false;
   const unsigned char* p = reinterpret_cast<const unsigned char*>(trimmed.c_str());
   const unsigned char* const end = p + trimmed.size();
   while (p < end) {
     const uint32_t cp = utf8NextCodepoint(&p);
-    if (cp == '.' || cp == '*' || cp == 0x2022) {
-      ++markerCount;
-      continue;
-    }
     if (cp == ' ' || cp == '\t') {
       continue;
     }
-    return false;
+    if (isLiteraryBreakCp(cp)) {
+      ++markerCount;
+      continue;
+    }
+    if (isMarkupBreakCp(cp)) {
+      markup = true;
+      if (cp == '=') {
+        sawEquals = true;
+      } else {
+        sawOtherMarkup = true;
+      }
+      ++markerCount;
+      continue;
+    }
+    return SceneBreakKind::None;
   }
 
-  if (markerCount == 0 || markerCount > 6) {
+  if (markerCount == 0) {
+    return SceneBreakKind::None;
+  }
+  if (markup) {
+    if (markerCount < 2) {
+      return SceneBreakKind::None;
+    }
+    // AsciiDoc / Calibre leftovers (`==`, `===`) mark a chapter or page boundary, not a scene ornament.
+    if (sawEquals && !sawOtherMarkup) {
+      return SceneBreakKind::PageBreak;
+    }
+    return SceneBreakKind::Markup;
+  }
+  if (markerCount > 6) {
+    return SceneBreakKind::None;
+  }
+  return SceneBreakKind::Literary;
+}
+
+bool isRomanNumeralToken(const std::string& text) {
+  if (text.empty() || text.size() > 8) {
     return false;
   }
-  if (markerText) *markerText = trimmed;
+  for (unsigned char c : text) {
+    const char u = static_cast<char>(std::toupper(c));
+    if (u != 'I' && u != 'V' && u != 'X' && u != 'L' && u != 'C' && u != 'M') {
+      return false;
+    }
+  }
   return true;
+}
+
+bool isNumericChapterToken(const std::string& text) {
+  if (text.empty() || text.size() > 6) {
+    return false;
+  }
+  for (unsigned char c : text) {
+    if (std::isdigit(c) == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool looksLikeChapterTitle(const std::string& text) {
+  const std::string trimmed = trimAsciiWhitespace(text);
+  if (trimmed.empty() || trimmed.find('\n') != std::string::npos) {
+    return false;
+  }
+  return isNumericChapterToken(trimmed) || isRomanNumeralToken(trimmed);
+}
+
+/** AsciiDoc (`==` / `===`) or Markdown ATX (`##`…) heading leftover. Empty title means a break-only line. */
+bool parseChapterHeadingMarkup(const std::string& line, std::string* titleOut) {
+  if (titleOut) {
+    titleOut->clear();
+  }
+  const std::string trimmed = trimAsciiWhitespace(line);
+  if (trimmed.size() < 2) {
+    return false;
+  }
+  const char mark = trimmed[0];
+  if (mark != '=' && mark != '#') {
+    return false;
+  }
+  size_t n = 0;
+  while (n < trimmed.size() && trimmed[n] == mark) {
+    ++n;
+  }
+  if (mark == '=' && (n < 2 || n > 3)) {
+    return false;
+  }
+  if (mark == '#' && (n < 2 || n > 6)) {
+    return false;
+  }
+  if (n == trimmed.size()) {
+    return true;
+  }
+  if (trimmed[n] == ' ' || trimmed[n] == '\t' ||
+      (mark == '=' && std::isalnum(static_cast<unsigned char>(trimmed[n])) != 0)) {
+    const std::string title = trimAsciiWhitespace(trimmed.substr(n));
+    if (titleOut) {
+      *titleOut = title;
+    }
+    return true;
+  }
+  return false;
+}
+
+/** Strips a Markdown ATX (`##`) or AsciiDoc (`==`) heading prefix. Returns true when a prefix was removed
+ *  and title text remains. A line that is only markers is left unchanged so classifySceneBreak can handle it. */
+bool stripHeadingMarkupPrefix(std::string& line) {
+  std::string title;
+  if (!parseChapterHeadingMarkup(line, &title) || title.empty()) {
+    return false;
+  }
+  line = std::move(title);
+  return true;
+}
+
+/** Drops separator-only lines and heading-underline leftovers from a text node. Empty result means the
+ *  whole node was markup (caller should emit a scene break). */
+std::string cleanChapterMarkupText(const std::string& text, const bool inHeader, SceneBreakKind* leftoverBreak) {
+  if (leftoverBreak) {
+    *leftoverBreak = SceneBreakKind::None;
+  }
+  std::string out;
+  size_t start = 0;
+  bool sawContent = false;
+  while (start <= text.size()) {
+    const size_t nl = text.find_first_of("\r\n", start);
+    const size_t end = nl == std::string::npos ? text.size() : nl;
+    std::string line = text.substr(start, end - start);
+    if (nl != std::string::npos && text[nl] == '\r' && nl + 1 < text.size() && text[nl + 1] == '\n') {
+      start = nl + 2;
+    } else if (nl != std::string::npos) {
+      start = nl + 1;
+    } else {
+      start = text.size() + 1;
+    }
+
+    std::string headingTitle;
+    if (parseChapterHeadingMarkup(line, &headingTitle)) {
+      if (leftoverBreak && *leftoverBreak == SceneBreakKind::None) {
+        *leftoverBreak = headingTitle.empty() ? SceneBreakKind::PageBreak : SceneBreakKind::ChapterHeading;
+      }
+      if (headingTitle.empty()) {
+        continue;
+      }
+      line = std::move(headingTitle);
+    } else {
+      const SceneBreakKind kind = classifySceneBreak(line);
+      if (kind != SceneBreakKind::None) {
+        if (leftoverBreak && *leftoverBreak == SceneBreakKind::None) {
+          *leftoverBreak = kind;
+        }
+        continue;
+      }
+      if (inHeader || !sawContent) {
+        stripHeadingMarkupPrefix(line);
+      }
+    }
+    line = trimAsciiWhitespace(line);
+    if (line.empty()) {
+      continue;
+    }
+    if (!out.empty()) {
+      out += '\n';
+    }
+    out += line;
+    sawContent = true;
+  }
+  return out;
 }
 
 }  // namespace
@@ -523,6 +741,10 @@ void ChapterHtmlSlimParser::resetStructuralStateForParsePass() {
   subscriptUntilDepth = INT_MAX;
   listNoIndentDepths_.clear();
   inHeader = false;
+  keepBodyOnThisPage_ = false;
+  pendingChapterTitle_ = false;
+  completedPageCount_ = 0;
+  chapterStarts_.clear();
   inDropCap = false;
   dropCapDepth = INT_MAX;
   dropCapConsumeWholeContainer = false;
@@ -920,6 +1142,74 @@ void ChapterHtmlSlimParser::flushPartWordBuffer() {
     return;
   }
 
+  if (currentTextBlock && currentTextBlock->isEmpty()) {
+    std::string firstToken(partWordBuffer, static_cast<size_t>(partWordBufferIndex));
+    std::string headingTitle;
+    if (parseChapterHeadingMarkup(firstToken, &headingTitle)) {
+      partWordBufferIndex = 0;
+      if (inHeader) {
+        if (headingTitle.empty()) {
+          startChapterOpening();
+          pendingChapterTitle_ = true;
+          return;
+        }
+        if (headingTitle.size() >= MAX_WORD_SIZE) {
+          return;
+        }
+        memcpy(partWordBuffer, headingTitle.c_str(), headingTitle.size());
+        partWordBufferIndex = static_cast<int>(headingTitle.size());
+        partWordBuffer[partWordBufferIndex] = '\0';
+        noteChapterMarker(headingTitle);
+      } else {
+        startChapterOpening();
+        if (!headingTitle.empty()) {
+          emitChapterHeading(headingTitle);
+        } else {
+          pendingChapterTitle_ = true;
+        }
+        return;
+      }
+    } else {
+      const SceneBreakKind kind = classifySceneBreak(firstToken);
+      if (kind != SceneBreakKind::None) {
+        partWordBufferIndex = 0;
+        if (!inHeader) {
+          if (kind == SceneBreakKind::Literary) {
+            addCenteredDivider("\xC2\xB7 \xC2\xB7 \xC2\xB7");
+          } else if (kind == SceneBreakKind::PageBreak || kind == SceneBreakKind::ChapterHeading) {
+            startChapterOpening();
+            pendingChapterTitle_ = true;
+          } else {
+            addQuietSceneBreak();
+          }
+        }
+        return;
+      }
+    }
+    if (pendingChapterTitle_ && looksLikeChapterTitle(firstToken)) {
+      pendingChapterTitle_ = false;
+      if (!inHeader) {
+        partWordBufferIndex = 0;
+        emitChapterHeading(firstToken);
+        return;
+      }
+      noteChapterMarker(firstToken);
+    } else if (inHeader && looksLikeChapterTitle(firstToken)) {
+      if (pageHasPriorContent()) {
+        startChapterOpening();
+      }
+      noteChapterMarker(firstToken);
+    } else if (stripHeadingMarkupPrefix(firstToken)) {
+      if (firstToken.size() >= MAX_WORD_SIZE) {
+        partWordBufferIndex = 0;
+        return;
+      }
+      memcpy(partWordBuffer, firstToken.c_str(), firstToken.size());
+      partWordBufferIndex = static_cast<int>(firstToken.size());
+      partWordBuffer[partWordBufferIndex] = '\0';
+    }
+  }
+
   const bool cssBoldActive = !cssFontStyleStack.empty() && cssFontStyleStack.back().bold;
   const bool cssItalicActive = !cssFontStyleStack.empty() && cssFontStyleStack.back().italic;
   EpdFontFamily::Style fontStyle = EpdFontFamily::REGULAR;
@@ -963,11 +1253,36 @@ void ChapterHtmlSlimParser::flushPartWordBuffer() {
   partWordBufferIndex = 0;
 }
 
+void ChapterHtmlSlimParser::flushWordPreservingJoinForFragment() {
+  if (partWordBufferIndex <= 0) {
+    return;
+  }
+  // Join across a style/tag boundary only for a true fragment: trailing hyphen, a single
+  // letter (drop-cap / first-letter span), or a script that does not separate words with
+  // spaces (CJK, Thai, …). Latin/Cyrillic two-letter words are complete tokens.
+  const bool hyphenFragment = partWordBuffer[static_cast<size_t>(partWordBufferIndex) - 1] == '-';
+  const unsigned char lead = static_cast<unsigned char>(partWordBuffer[0]);
+  const int letterBytes = utf8CodepointByteLength(lead);
+  const bool singleLetter = letterBytes == partWordBufferIndex;
+  const bool joiningScript = tokenUsesJoiningScript(partWordBuffer, partWordBufferIndex);
+  flushPartWordBuffer();
+  nextWordJoinsPrevious = hyphenFragment || singleLetter || joiningScript;
+}
+
 void ChapterHtmlSlimParser::applyVerticalSpacing(const int px) {
   if (px <= 0) {
     return;
   }
-  if (currentPageNextY + px > viewportHeight) {
+  int add = px;
+  if (keepBodyOnThisPage_ || inHeader) {
+    add = clampSpacingToKeepBody(add);
+    if (add <= 0) {
+      return;
+    }
+    currentPageNextY = static_cast<int16_t>(currentPageNextY + add);
+    return;
+  }
+  if (currentPageNextY + add > viewportHeight) {
     if (currentPage && !currentPage->elements.empty()) {
       completeCurrentPage();
     }
@@ -975,7 +1290,7 @@ void ChapterHtmlSlimParser::applyVerticalSpacing(const int px) {
     currentPageNextY = 0;
     return;
   }
-  currentPageNextY += px;
+  currentPageNextY += add;
 }
 
 void ChapterHtmlSlimParser::flushCurrentTableCell() {
@@ -1545,7 +1860,11 @@ void ChapterHtmlSlimParser::beginCssBlockBox(const std::string& tagLower, const 
     return;
   }
 
-  if (currentPageNextY > 0 && (marginTop > 0 || currentBlockUsesBorderBox)) {
+  if (keepBodyOnThisPage_) {
+    if (marginTop > 0) {
+      applyVerticalSpacing(marginTop);
+    }
+  } else if (currentPageNextY > 0 && (marginTop > 0 || currentBlockUsesBorderBox)) {
     // Reserving a block's full margin-top can leave just enough room for the margin but not the block's own
     // first line (or, for a bordered box, its chrome plus a couple of content lines) - bouncing the whole
     // block to the next page and leaving that margin's worth of space sitting unused on this one (real
@@ -1729,8 +2048,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
   const bool resolvedSmallCaps = inheritedSmallCaps || hasExplicitSmallCapsHint(name, classAttr, idAttr, styleAttr);
   // Flush any pending word before the small-caps state changes so the preceding text keeps its flag.
   if (resolvedSmallCaps != inheritedSmallCaps && self->partWordBufferIndex > 0) {
-    self->flushPartWordBuffer();
-    self->nextWordJoinsPrevious = true;
+    self->flushWordPreservingJoinForFragment();
   }
   self->smallCapsStack.push_back(resolvedSmallCaps);
   self->smallCapsDepths.push_back(self->depth);
@@ -1742,8 +2060,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       self->css().resolveFontItalic(tagLower, classAttr, idAttr, styleAttr, inheritedCssItalic);
   if ((resolvedCssBold != inheritedCssBold || resolvedCssItalic != inheritedCssItalic) &&
       self->partWordBufferIndex > 0) {
-    self->flushPartWordBuffer();
-    self->nextWordJoinsPrevious = true;
+    self->flushWordPreservingJoinForFragment();
   }
   CssFontStyleScope fontScope;
   fontScope.depth = self->depth;
@@ -1761,8 +2078,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
   }
   if (elementVerticalAlign != TextBlock::BASELINE) {
     if (self->partWordBufferIndex > 0) {
-      self->flushPartWordBuffer();
-      self->nextWordJoinsPrevious = true;
+      self->flushWordPreservingJoinForFragment();
     }
     if (elementVerticalAlign == TextBlock::SUPERSCRIPT) {
       self->superscriptUntilDepth = self->depth;
@@ -1824,6 +2140,11 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
 
   if (isHeaderTag) {
     self->flushPartWordBuffer();
+    if (self->pendingChapterTitle_ || strcmp(name, "h1") == 0 ||
+        self->css().isPageBreakBeforeAlways(tagLower, classAttr, idAttr, styleAttr)) {
+      self->startChapterOpening();
+      self->pendingChapterTitle_ = false;
+    }
     // Lay out the previous (non-header) block with its own context/spacing before switching to header mode,
     // so its margin-bottom isn't overwritten by the header's spacing fields.
     if (self->currentTextBlock && !self->currentTextBlock->isEmpty()) {
@@ -1851,13 +2172,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       if (self->currentTextBlock) self->startNewTextBlock(self->currentTextBlock->getStyle());
     } else {
       if (self->css().isPageBreakBeforeAlways(tagLower, classAttr, idAttr, styleAttr)) {
-        if (self->currentTextBlock && !self->currentTextBlock->isEmpty()) {
-          self->makePages();
-        }
-        if (self->currentPage && !self->currentPage->elements.empty()) {
-          self->completeCurrentPage();
-          self->currentPageNextY = 0;
-        }
+        self->startChapterOpening();
       }
       const TextBlock::Style blockStyle =
           self->resolveBlockStyle(name, atts, elementHasExplicitTextAlign, elementCssStyle, inheritedCssStyle);
@@ -1966,24 +2281,66 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
   }
   if (self->skipUntilDepth < self->depth) return;
 
-  std::string sceneBreakText;
-  if ((!self->currentTextBlock || self->currentTextBlock->isEmpty()) &&
-      isSceneBreakMarker(std::string(reinterpret_cast<const char*>(s), static_cast<size_t>(len)), &sceneBreakText)) {
-    self->addCenteredDivider(sceneBreakText.c_str());
-    return;
+  const bool blockEmpty = !self->currentTextBlock || self->currentTextBlock->isEmpty();
+  std::string cleaned;
+  const char* chars = reinterpret_cast<const char*>(s);
+  int charLen = len;
+  if (blockEmpty && !self->inDropCap) {
+    SceneBreakKind leftover = SceneBreakKind::None;
+    cleaned = cleanChapterMarkupText(std::string(chars, static_cast<size_t>(len)), self->inHeader, &leftover);
+    if (cleaned.empty()) {
+      if (!self->inHeader) {
+        if (leftover == SceneBreakKind::Literary) {
+          self->addCenteredDivider("\xC2\xB7 \xC2\xB7 \xC2\xB7");
+        } else if (leftover == SceneBreakKind::PageBreak || leftover == SceneBreakKind::ChapterHeading) {
+          self->startChapterOpening();
+          self->pendingChapterTitle_ = true;
+        } else if (leftover == SceneBreakKind::Markup) {
+          self->addQuietSceneBreak();
+        }
+      }
+      return;
+    }
+    if (!self->inHeader &&
+        (leftover == SceneBreakKind::PageBreak || leftover == SceneBreakKind::ChapterHeading)) {
+      self->startChapterOpening();
+      const size_t nl = cleaned.find('\n');
+      const std::string heading = nl == std::string::npos ? cleaned : cleaned.substr(0, nl);
+      if (leftover == SceneBreakKind::ChapterHeading || looksLikeChapterTitle(heading)) {
+        self->emitChapterHeading(heading);
+        if (nl == std::string::npos) {
+          return;
+        }
+        cleaned = cleaned.substr(nl + 1);
+      } else {
+        self->pendingChapterTitle_ = true;
+      }
+    }
+    chars = cleaned.c_str();
+    charLen = static_cast<int>(cleaned.size());
   }
 
-  for (int i = 0; i < len; i++) {
-    if (isWhitespace(s[i])) {
+  int i = 0;
+  while (i < charLen) {
+    const unsigned char lead = static_cast<unsigned char>(chars[i]);
+    int clen = utf8CodepointByteLength(lead);
+    if (i + clen > charLen) {
+      clen = charLen - i;
+    }
+    uint32_t cp = lead;
+    if (clen > 1) {
+      unsigned char tmp[5] = {0, 0, 0, 0, 0};
+      memcpy(tmp, chars + i, static_cast<size_t>(clen));
+      const unsigned char* p = tmp;
+      cp = utf8NextCodepoint(&p);
+    }
+
+    if (isWordSeparatorCp(cp) || isWhitespace(chars[i])) {
       if (!self->inDropCap) {
         self->flushPartWordBuffer();
         self->nextWordJoinsPrevious = false;
       }
-      continue;
-    }
-
-    if (s[i] == (XML_Char)0xEF && i + 2 < len && s[i + 1] == (XML_Char)0xBB && s[i + 2] == (XML_Char)0xBF) {
-      i += 2;
+      i += clen;
       continue;
     }
 
@@ -1999,13 +2356,15 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
           new PageListMarker("\xC2\xB7", self->pendingListMarkerX_, self->currentPageNextY, self->activeBlockFontId()));
     }
 
-    if (!self->inDropCap && self->partWordBufferIndex >= MAX_WORD_SIZE) {
-      self->flushPartWordBuffer();
+    for (int b = 0; b < clen; ++b) {
+      if (!self->inDropCap && self->partWordBufferIndex >= MAX_WORD_SIZE) {
+        self->flushPartWordBuffer();
+      }
+      if (self->partWordBufferIndex >= MAX_WORD_SIZE) {
+        break;
+      }
+      self->partWordBuffer[self->partWordBufferIndex++] = chars[i + b];
     }
-    if (self->partWordBufferIndex >= MAX_WORD_SIZE) {
-      continue;
-    }
-    self->partWordBuffer[self->partWordBufferIndex++] = s[i];
 
     if (self->inDropCap && endsWithCompleteUtf8Codepoint(self->partWordBuffer, self->partWordBufferIndex) &&
         countUtf8Codepoints(self->partWordBuffer, self->partWordBufferIndex) >=
@@ -2013,6 +2372,7 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
                                      self->dropCapConsumeWholeContainer)) {
       self->flushPartWordBuffer();
     }
+    i += clen;
   }
 
   if (self->currentTextBlock && self->currentTextBlock->size() > STREAMING_TEXTBLOCK_WORD_LIMIT) {
@@ -2067,9 +2427,14 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
   }
 
   if (self->partWordBufferIndex > 0) {
-    if (matches(name, BLOCK_TAGS, NUM_BLOCK_TAGS) || matches(name, HEADER_TAGS, NUM_HEADER_TAGS) ||
-        matches(name, BOLD_TAGS, NUM_BOLD_TAGS) || matches(name, ITALIC_TAGS, NUM_ITALIC_TAGS) || self->depth == 1) {
+    if (matches(name, BLOCK_TAGS, NUM_BLOCK_TAGS) || matches(name, HEADER_TAGS, NUM_HEADER_TAGS) || self->depth == 1) {
       self->flushPartWordBuffer();
+    } else if (matches(name, BOLD_TAGS, NUM_BOLD_TAGS) || matches(name, ITALIC_TAGS, NUM_ITALIC_TAGS) ||
+               strcmp(name, "span") == 0 || strcmp(name, "a") == 0 || strcmp(name, "font") == 0) {
+      // EPUB converters often wrap a complete word in <span>/<i> with no space before the next
+      // word. Flush here so space-separated scripts get a word break; joining scripts and
+      // single-letter fragments still concatenate via flushWordPreservingJoinForFragment.
+      self->flushWordPreservingJoinForFragment();
     }
   }
   const int closingDepth = self->depth - 1;
@@ -2083,14 +2448,12 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
                                   ? self->cssFontStyleStack[self->cssFontStyleStack.size() - 2].italic
                                   : false;
     if (closingBold != parentBold || closingItalic != parentItalic) {
-      self->flushPartWordBuffer();
-      self->nextWordJoinsPrevious = true;
+      self->flushWordPreservingJoinForFragment();
     }
   }
   if (self->partWordBufferIndex > 0 &&
       (self->superscriptUntilDepth == closingDepth || self->subscriptUntilDepth == closingDepth)) {
-    self->flushPartWordBuffer();
-    self->nextWordJoinsPrevious = true;
+    self->flushWordPreservingJoinForFragment();
   }
 
   if (matches(name, HEADER_TAGS, NUM_HEADER_TAGS)) {
@@ -2245,8 +2608,7 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
     // Flush the trailing word (e.g. "note" in "<span class=smallcaps>author's note</span>") while the
     // small-caps flag is still active, before the scope is popped.
     if (wasSmallCaps != nowSmallCaps && self->partWordBufferIndex > 0) {
-      self->flushPartWordBuffer();
-      self->nextWordJoinsPrevious = true;
+      self->flushWordPreservingJoinForFragment();
     }
     self->smallCapsDepths.pop_back();
     self->smallCapsStack.pop_back();
@@ -2350,6 +2712,92 @@ void ChapterHtmlSlimParser::restartOpenBorderBoxesAfterPageBreak() {
   }
 }
 
+int ChapterHtmlSlimParser::spaceToKeepForBody() const {
+  const int lineH = std::max(1, static_cast<int>(renderer.text.getLineHeight(fontId) * lineCompression));
+  return lineH * 4;
+}
+
+int ChapterHtmlSlimParser::clampSpacingToKeepBody(const int px) const {
+  const int keep = spaceToKeepForBody();
+  const int maxPx = static_cast<int>(viewportHeight) - static_cast<int>(currentPageNextY) - keep;
+  if (maxPx <= 0) {
+    return 0;
+  }
+  return std::min(px, maxPx);
+}
+
+bool ChapterHtmlSlimParser::pageHasPriorContent() const {
+  return currentPage && !currentPage->elements.empty() && currentPageNextY > viewportHeight / 8;
+}
+
+void ChapterHtmlSlimParser::noteChapterMarker(const std::string& title) {
+  if (imagePrefetchPassOnly_ || title.empty()) {
+    return;
+  }
+  const uint16_t page = completedPageCount_;
+  if (!chapterStarts_.empty() && chapterStarts_.back().page == page) {
+    chapterStarts_.back().title = title;
+    return;
+  }
+  if (chapterStarts_.size() >= 128) {
+    return;
+  }
+  ChapterStart start;
+  start.page = page;
+  start.title = title;
+  chapterStarts_.push_back(std::move(start));
+}
+
+void ChapterHtmlSlimParser::startChapterOpening() {
+  if (currentTextBlock && !currentTextBlock->isEmpty()) {
+    makePages();
+  }
+  forcePageBreak();
+  keepBodyOnThisPage_ = true;
+  if (!currentPage) {
+    currentPage.reset(new Page());
+    currentPageNextY = 0;
+  }
+  if (currentPageNextY == 0) {
+    const int lineH = std::max(1, static_cast<int>(renderer.text.getLineHeight(headerFontId) * lineCompression));
+    applyVerticalSpacing(std::min(lineH * 2, static_cast<int>(viewportHeight) / 6));
+  }
+}
+
+void ChapterHtmlSlimParser::emitChapterHeading(const std::string& title) {
+  const std::string trimmed = trimAsciiWhitespace(title);
+  if (trimmed.empty()) {
+    return;
+  }
+  startChapterOpening();
+  const bool restoreHeader = inHeader;
+  inHeader = true;
+  startNewTextBlock(TextBlock::CENTER_ALIGN);
+  if (currentTextBlock) {
+    currentTextBlock->addWord(trimmed, EpdFontFamily::BOLD, false);
+  }
+  makePages();
+  inHeader = restoreHeader;
+  noteChapterMarker(trimmed);
+  keepBodyOnThisPage_ = true;
+  pendingChapterTitle_ = false;
+  const TextBlock::Style bodyStyle =
+      paragraphAlignment <= 3 ? static_cast<TextBlock::Style>(paragraphAlignment) : TextBlock::JUSTIFIED;
+  startNewTextBlock(bodyStyle);
+  const int lineH = std::max(1, static_cast<int>(renderer.text.getLineHeight(fontId) * lineCompression));
+  applyVerticalSpacing(std::min(lineH * 2, clampSpacingToKeepBody(lineH * 2)));
+}
+
+void ChapterHtmlSlimParser::forcePageBreak() {
+  if (currentTextBlock && !currentTextBlock->isEmpty()) {
+    makePages();
+  }
+  if (currentPage && !currentPage->elements.empty()) {
+    completeCurrentPage();
+    currentPageNextY = 0;
+  }
+}
+
 void ChapterHtmlSlimParser::completeCurrentPage() {
   if (!currentPage || currentPage->elements.empty()) {
     return;
@@ -2369,6 +2817,9 @@ void ChapterHtmlSlimParser::completeCurrentPage() {
 
   currentPage->trimElementStorage();
   completePageFn(std::move(currentPage));
+  if (completedPageCount_ < 0xFFFF) {
+    ++completedPageCount_;
+  }
   for (auto& scope : cssBorderBoxStack) {
     scope.elem = nullptr;
   }
@@ -2392,6 +2843,14 @@ void ChapterHtmlSlimParser::addCenteredDivider(const char* text) {
                                  [this](TextBlock&& textBlock) { addLineToPage(std::move(textBlock)); });
 
   applyVerticalSpacing(spacer);
+}
+
+void ChapterHtmlSlimParser::addQuietSceneBreak() {
+  if (currentTextBlock && !currentTextBlock->isEmpty()) {
+    makePages();
+  }
+  const int lineHeight = renderer.text.getLineHeight(fontId) * lineCompression;
+  applyVerticalSpacing(std::max(8, lineHeight));
 }
 
 void ChapterHtmlSlimParser::addHorizontalRule(const std::string& tagLower, const std::string& classAttr,
@@ -2593,6 +3052,9 @@ void ChapterHtmlSlimParser::makePages(bool deferClosingSpacingToCaller) {
   pendingBorderBoxElem_ = nullptr;
   currentBlockMinHeightPx = 0;
   currentBlockFontId = -1;
+  if (!inHeader && keepBodyOnThisPage_ && currentPage && !currentPage->elements.empty()) {
+    keepBodyOnThisPage_ = false;
+  }
 }
 
 /**

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1274,7 +1274,7 @@ void ChapterHtmlSlimParser::applyVerticalSpacing(const int px) {
     return;
   }
   int add = px;
-  if (keepBodyOnThisPage_ || inHeader) {
+  if (keepBodyOnThisPage_ || inHeader || openingWaitingForBody()) {
     add = clampSpacingToKeepBody(add);
     if (add <= 0) {
       return;
@@ -1701,6 +1701,11 @@ int ChapterHtmlSlimParser::cssBorderInnerGapPx() const {
 
 void ChapterHtmlSlimParser::applyMinHeightPadding() {
   if (currentBlockMinHeightPx <= 0) return;
+  // Print CSS often gives chapter numbers min-height: 80%/100% so the heading sits on its own leaf.
+  // On this screen that is a blank page with "9" at the top - skip it until body text is on the page.
+  if (inHeader || openingWaitingForBody()) {
+    return;
+  }
   // Skip if the block wrapped onto a new page (content start Y no longer comparable to the current cursor).
   if (currentPageNextY < currentBlockContentStartY) return;
   const int contentHeight = currentPageNextY - currentBlockContentStartY;
@@ -2657,11 +2662,16 @@ void ChapterHtmlSlimParser::addLineToPage(TextBlock&& line) {
   if (line.isEmpty()) return;
 
   if (currentPageNextY + lineHeight > viewportHeight) {
-    finalizeOpenBorderBoxesForPageBreak();
-    completeCurrentPage();
-    currentPage.reset(new Page());
-    currentPageNextY = 0;
-    restartOpenBorderBoxesAfterPageBreak();
+    if (openingWaitingForBody()) {
+      currentPageNextY =
+          static_cast<int16_t>(std::max(0, static_cast<int>(viewportHeight) - lineHeight));
+    } else {
+      finalizeOpenBorderBoxesForPageBreak();
+      completeCurrentPage();
+      currentPage.reset(new Page());
+      currentPageNextY = 0;
+      restartOpenBorderBoxesAfterPageBreak();
+    }
   }
 
   if (!currentPage) currentPage.reset(new Page());
@@ -2678,6 +2688,9 @@ void ChapterHtmlSlimParser::addLineToPage(TextBlock&& line) {
   }
 
   currentPageNextY += lineHeight;
+  if (!inHeader && currentBlockFontId < 0) {
+    keepBodyOnThisPage_ = false;
+  }
 }
 
 void ChapterHtmlSlimParser::finalizeOpenBorderBoxesForPageBreak() {
@@ -2730,6 +2743,29 @@ bool ChapterHtmlSlimParser::pageHasPriorContent() const {
   return currentPage && !currentPage->elements.empty() && currentPageNextY > viewportHeight / 8;
 }
 
+bool ChapterHtmlSlimParser::pageHasBodyText() const {
+  if (!currentPage) {
+    return false;
+  }
+  for (const auto& el : currentPage->elements) {
+    if (!el) {
+      continue;
+    }
+    switch (el->getTag()) {
+      case TAG_PageLine:
+      case TAG_PageSmallCaps:
+      case TAG_PageDropCap:
+      case TAG_PageTable:
+        return true;
+      default:
+        break;
+    }
+  }
+  return false;
+}
+
+bool ChapterHtmlSlimParser::openingWaitingForBody() const { return keepBodyOnThisPage_ && !pageHasBodyText(); }
+
 void ChapterHtmlSlimParser::noteChapterMarker(const std::string& title) {
   if (imagePrefetchPassOnly_ || title.empty()) {
     return;
@@ -2751,6 +2787,11 @@ void ChapterHtmlSlimParser::noteChapterMarker(const std::string& title) {
 void ChapterHtmlSlimParser::startChapterOpening() {
   if (currentTextBlock && !currentTextBlock->isEmpty()) {
     makePages();
+  }
+  // EPUB CSS repeats page-break-before on the number, the title, the wrapping div, and the first
+  // paragraph. Breaking on each of those leaves a lone "9" on an otherwise empty page.
+  if (openingWaitingForBody()) {
+    return;
   }
   forcePageBreak();
   keepBodyOnThisPage_ = true;
@@ -2789,6 +2830,9 @@ void ChapterHtmlSlimParser::emitChapterHeading(const std::string& title) {
 }
 
 void ChapterHtmlSlimParser::forcePageBreak() {
+  if (openingWaitingForBody()) {
+    return;
+  }
   if (currentTextBlock && !currentTextBlock->isEmpty()) {
     makePages();
   }
@@ -3052,9 +3096,6 @@ void ChapterHtmlSlimParser::makePages(bool deferClosingSpacingToCaller) {
   pendingBorderBoxElem_ = nullptr;
   currentBlockMinHeightPx = 0;
   currentBlockFontId = -1;
-  if (!inHeader && keepBodyOnThisPage_ && currentPage && !currentPage->elements.empty()) {
-    keepBodyOnThisPage_ = false;
-  }
 }
 
 /**

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -323,6 +323,8 @@ class ChapterHtmlSlimParser {
   int spaceToKeepForBody() const;
   int clampSpacingToKeepBody(int px) const;
   bool pageHasPriorContent() const;
+  bool pageHasBodyText() const;
+  bool openingWaitingForBody() const;
   void addCenteredDivider(const char* text);
   void addQuietSceneBreak();
   void addHorizontalRule(const std::string& tagLower = "hr", const std::string& classAttr = "",

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -9,6 +9,7 @@
 #include <expat.h>
 
 #include <climits>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
@@ -38,6 +39,12 @@ constexpr uint8_t EPUB_PARAGRAPH_ALIGNMENT_FOLLOW_CSS = 4;
  * Handles XML parsing, text layout, and image processing for EPUB chapters.
  */
 class ChapterHtmlSlimParser {
+ public:
+  struct ChapterStart {
+    uint16_t page = 0;
+    std::string title;
+  };
+
  private:
   const std::string& filepath;
   const Epub& epub;
@@ -66,6 +73,10 @@ class ChapterHtmlSlimParser {
   int maxFontId;
 
   bool inHeader = false;
+  bool keepBodyOnThisPage_ = false;
+  bool pendingChapterTitle_ = false;
+  uint16_t completedPageCount_ = 0;
+  std::vector<ChapterStart> chapterStarts_;
 
   bool inDropCap = false;
   int dropCapDepth = INT_MAX;
@@ -262,6 +273,9 @@ class ChapterHtmlSlimParser {
   void startNewTextBlock(TextBlock::Style style);
   void applyVerticalSpacing(int px);
   void flushCurrentTableCell();
+  /** Flush the current word. Only join the next token when this one looks like a mid-word fragment
+   *  (1–2 bytes, or a hyphenated prefix) so a styled complete word is not glued to the following one. */
+  void flushWordPreservingJoinForFragment();
   void flushCurrentTableRow();
   void appendTableText(const XML_Char* s, int len);
   void addTableToPage();
@@ -300,7 +314,17 @@ class ChapterHtmlSlimParser {
   void completeCurrentPage();
   void finalizeOpenBorderBoxesForPageBreak();
   void restartOpenBorderBoxesAfterPageBreak();
+  /** Finish the current page when it already has content, so the next block starts on a fresh page. */
+  void forcePageBreak();
+  /** Page-break if this page already has body text, then apply a modest chapter-opening top spacer. */
+  void startChapterOpening();
+  void emitChapterHeading(const std::string& title);
+  void noteChapterMarker(const std::string& title);
+  int spaceToKeepForBody() const;
+  int clampSpacingToKeepBody(int px) const;
+  bool pageHasPriorContent() const;
   void addCenteredDivider(const char* text);
+  void addQuietSceneBreak();
   void addHorizontalRule(const std::string& tagLower = "hr", const std::string& classAttr = "",
                          const std::string& idAttr = "", const std::string& styleAttr = "");
   /** Emits a horizontal border rule (full content width placeholder) and returns it so its width can be
@@ -382,6 +406,8 @@ class ChapterHtmlSlimParser {
 
  public:
   std::string internalPath;
+
+  const std::vector<ChapterStart>& chapterStarts() const { return chapterStarts_; }
 
   /**
    * Constructs a new HTML parser for a chapter.

--- a/src/activity/reader/Epub/EpubActivity.cpp
+++ b/src/activity/reader/Epub/EpubActivity.cpp
@@ -2159,7 +2159,9 @@ void EpubActivity::goToBookmark(int index) {
  * @return Chapter title string
  */
 std::string EpubActivity::getCurrentChapterTitle() const {
-  int tocIndex = epub->getTocIndexForSpineIndex(currentSpineIndex);
+  const int page = section ? section->currentPage : 0;
+  const int count = section ? section->pageCount : 0;
+  const int tocIndex = epub->getTocIndexForSpinePage(currentSpineIndex, page, count);
   if (tocIndex != -1) {
     return epub->getTocItem(tocIndex).title;
   }

--- a/src/activity/reader/Epub/EpubReadingStats.cpp
+++ b/src/activity/reader/Epub/EpubReadingStats.cpp
@@ -143,7 +143,12 @@ std::string EpubReadingStats::chapterTimeLeftString(const Section* section) cons
     return "-";
   }
 
-  const int remainingPages = static_cast<int>(section->pageCount) - section->currentPage - 1;
+  int remainingPages = static_cast<int>(section->pageCount) - section->currentPage - 1;
+  int start = 0;
+  int count = 0;
+  if (section->chapterRangeForPage(section->currentPage, &start, &count) && count > 0) {
+    remainingPages = start + count - section->currentPage - 1;
+  }
   if (remainingPages <= 0) {
     return "-";
   }

--- a/src/activity/reader/Epub/StatusBar.cpp
+++ b/src/activity/reader/Epub/StatusBar.cpp
@@ -7,6 +7,8 @@
 
 #include <HalGPIO.h>
 
+#include <cctype>
+
 #include "system/Fonts.h"
 #include "system/ScreenComponents.h"
 
@@ -180,7 +182,7 @@ void StatusBar::renderSection(int position, int sectionStart, int sectionCenter,
   const float bookProgress = calculateBookProgress(section, currentSpineIndex);
   const std::string pageStr = getPageString(section);
   const std::string percentStr = getPercentString(bookProgress);
-  const std::string chapterTitle = getChapterTitle(currentSpineIndex);
+  const std::string chapterTitle = getChapterTitle(currentSpineIndex, section);
   const std::string batteryPercentStr = getBatteryPercentString();
 
   auto getRightAlignedX = [&](const char* text) -> int {
@@ -363,6 +365,13 @@ void StatusBar::renderPageBars(int sectionStart, int sectionCenter, int sectionW
   const int minBarWidth = 2;
 
   int pageCount = static_cast<int>(section->pageCount);
+  int currentPage = section->currentPage;
+  int chapterStart = 0;
+  int chapterCount = 0;
+  if (section->chapterRangeForPage(section->currentPage, &chapterStart, &chapterCount) && chapterCount > 0) {
+    pageCount = chapterCount;
+    currentPage = section->currentPage - chapterStart;
+  }
   int barCount = (pageCount < maxBars) ? pageCount : maxBars;
   int pagesPerBar = pageCount / barCount;
   if (pagesPerBar < 1) pagesPerBar = 1;
@@ -373,7 +382,6 @@ void StatusBar::renderPageBars(int sectionStart, int sectionCenter, int sectionW
   int totalWidth = barCount * barWidth;
   int barStartX = sectionCenter - (totalWidth / 2);
 
-  int currentPage = section->currentPage;
   int barY = textY + 10;
 
   for (int i = 0; i < barCount; i++) {
@@ -425,8 +433,16 @@ StatusBarSectionConfig StatusBar::getConfig(int position) const {
  */
 std::string StatusBar::getPageString(const Section* section) const {
   if (!section) return "0/0";
+  int start = 0;
+  int count = 0;
+  int current = section->currentPage + 1;
+  int total = section->pageCount;
+  if (section->chapterRangeForPage(section->currentPage, &start, &count) && count > 0) {
+    current = section->currentPage - start + 1;
+    total = count;
+  }
   char buffer[16];
-  snprintf(buffer, sizeof(buffer), "%d/%d", section->currentPage + 1, section->pageCount);
+  snprintf(buffer, sizeof(buffer), "%d/%d", current, total);
   return std::string(buffer);
 }
 
@@ -460,12 +476,85 @@ std::string StatusBar::getBatteryPercentString() const {
  * @param currentSpineIndex Current spine index
  * @return Chapter title
  */
-std::string StatusBar::getChapterTitle(int currentSpineIndex) const {
-  int tocIndex = m_epub.getTocIndexForSpineIndex(currentSpineIndex);
-  if (tocIndex != -1) {
-    return m_epub.getTocItem(tocIndex).title;
+std::string StatusBar::getChapterTitle(int currentSpineIndex, const Section* section) const {
+  const int page = section ? section->currentPage : 0;
+  if (currentSpineIndex == cachedChapterSpine_ && page == cachedChapterPage_ && !cachedChapterTitle_.empty()) {
+    return cachedChapterTitle_;
   }
-  return "Chapter " + std::to_string(currentSpineIndex + 1);
+
+  auto titlesMatch = [](const std::string& tocTitle, const std::string& heading) {
+    auto normalize = [](const std::string& s) {
+      std::string out;
+      out.reserve(s.size());
+      for (unsigned char c : s) {
+        if (std::isalnum(c) != 0 || c >= 0x80) {
+          out.push_back(static_cast<char>(std::tolower(c)));
+        }
+      }
+      return out;
+    };
+    const std::string a = normalize(tocTitle);
+    const std::string b = normalize(heading);
+    if (a.empty() || b.empty()) {
+      return false;
+    }
+    return a == b || (a.size() >= b.size() && a.compare(a.size() - b.size(), b.size(), b) == 0);
+  };
+
+  const int count = section ? section->pageCount : 0;
+  std::string chapter;
+  int tocIndex = -1;
+  if (section) {
+    if (const auto* marker = section->chapterMarkerForPage(page)) {
+      chapter = marker->title;
+      const int tocCount = m_epub.getTocItemsCount();
+      int start = m_epub.getTocIndexForSpineIndex(currentSpineIndex);
+      if (start < 0 || start >= tocCount) {
+        start = 0;
+      }
+      bool seenSameSpine = false;
+      for (int i = start; i < tocCount; ++i) {
+        const auto item = m_epub.getTocItem(i);
+        if (item.spineIndex != currentSpineIndex) {
+          if (seenSameSpine) {
+            break;
+          }
+          continue;
+        }
+        seenSameSpine = true;
+        if (titlesMatch(item.title, chapter)) {
+          tocIndex = i;
+        }
+      }
+    }
+  }
+  if (chapter.empty()) {
+    tocIndex = m_epub.getTocIndexForSpinePage(currentSpineIndex, page, count);
+    if (tocIndex != -1) {
+      chapter = m_epub.getTocItem(tocIndex).title;
+    } else {
+      cachedChapterSpine_ = currentSpineIndex;
+      cachedChapterPage_ = page;
+      cachedChapterTitle_ = "Chapter " + std::to_string(currentSpineIndex + 1);
+      return cachedChapterTitle_;
+    }
+  }
+  if (tocIndex > 0) {
+    const auto leaf = m_epub.getTocItem(tocIndex);
+    for (int i = tocIndex - 1; i >= 0; --i) {
+      const auto parent = m_epub.getTocItem(i);
+      if (parent.level < leaf.level && !parent.title.empty() && parent.title != chapter) {
+        cachedChapterSpine_ = currentSpineIndex;
+        cachedChapterPage_ = page;
+        cachedChapterTitle_ = parent.title + " \xC2\xB7 " + chapter;
+        return cachedChapterTitle_;
+      }
+    }
+  }
+  cachedChapterSpine_ = currentSpineIndex;
+  cachedChapterPage_ = page;
+  cachedChapterTitle_ = chapter;
+  return cachedChapterTitle_;
 }
 
 /**
@@ -476,6 +565,6 @@ std::string StatusBar::getChapterTitle(int currentSpineIndex) const {
  */
 float StatusBar::calculateBookProgress(const Section* section, int currentSpineIndex) const {
   if (!section || section->pageCount == 0) return 0;
-  float spineProgress = static_cast<float>(section->currentPage) / section->pageCount;
+  const float spineProgress = epubSpineReadFraction(section->currentPage, section->pageCount);
   return m_epub.calculateProgress(currentSpineIndex, spineProgress) * 100;
 }

--- a/src/activity/reader/Epub/StatusBar.h
+++ b/src/activity/reader/Epub/StatusBar.h
@@ -139,7 +139,7 @@ class StatusBar {
    * @param currentSpineIndex Current spine index
    * @return Chapter title
    */
-  std::string getChapterTitle(int currentSpineIndex) const;
+  std::string getChapterTitle(int currentSpineIndex, const Section* section) const;
 
   /**
    * @brief Calculates overall book progress
@@ -154,6 +154,9 @@ class StatusBar {
   const BookSettings& m_settings;
   const EpubReadingStats* m_readingStats;
   bool m_visible;
+  mutable int cachedChapterSpine_ = -1;
+  mutable int cachedChapterPage_ = -1;
+  mutable std::string cachedChapterTitle_;
 };
 
 #endif


### PR DESCRIPTION
A chapter heading (`h1`, or a line of `==` / `===` in some conversions) was flushing as its own page, so you got a title-only screen and then the body. Nested TOC entries in one spine file also showed the wrapping part title and a spine-wide `45/260` in the status bar.

The parser now keeps the heading with the first paragraph, records in-section chapter markers, and rebuilds cached sections (version 77). The status bar and time-left use those markers: `3/12` inside the chapter, and the nested TOC title when several chapters share a spine.

Joining-script runs (CJK, etc.) still stay one token; space-separated scripts still break on space so dictionary/highlight do not glue English words together.

## Test on device
- Open a book whose chapters start with a large heading: first page should show heading + body, not heading alone
- Status bar page count should restart per chapter, not run across the whole spine
- Nested TOC (part then chapter) should show the chapter title, not only the part
- Chapter time-left should count remaining pages in this chapter
- After flashing, first open of an already-cached book rebuilds that section (version bump)

Made with [Cursor](https://cursor.com)