### PR TITLE
Join hyphen-wrapped words so dictionary lookup matches the whole word

### DIFF
--- a/lib/Epub/Epub/PageWordIndex.cpp
+++ b/lib/Epub/Epub/PageWordIndex.cpp
@@ -7,6 +7,8 @@
 #include <EpdFontFamily.h>
 #include <GfxRenderer.h>
 
+#include <cctype>
+
 void buildPageWordIndex(const Page& page, GfxRenderer& renderer, const int bodyFontId, const int headerFontId,
                         const int marginLeft, const int marginTop, std::vector<PageWordHit>& out,
                         std::vector<size_t>* lineStartsOut, const bool omitStoredWordStrings) {
@@ -120,4 +122,67 @@ void buildPageWordIndex(const Page& page, GfxRenderer& renderer, const int bodyF
         break;
     }
   }
+  markHyphenJoins(out);
+}
+
+bool isLineBreakHyphenPrefix(const std::string& text) {
+  if (text.size() < 2 || text.back() != '-') {
+    return false;
+  }
+  const unsigned char before = static_cast<unsigned char>(text[text.size() - 2]);
+  return std::isalpha(before) != 0 || before >= 0x80;
+}
+
+void markHyphenJoins(std::vector<PageWordHit>& words) {
+  if (words.empty()) {
+    return;
+  }
+  for (size_t i = 0; i + 1 < words.size(); ++i) {
+    if (!isLineBreakHyphenPrefix(words[i].text)) {
+      continue;
+    }
+    if (words[i + 1].screenY > words[i].screenY + 1) {
+      words[i].hyphenJoinNext = true;
+      words[i + 1].hyphenJoinPrev = true;
+    }
+  }
+  if (isLineBreakHyphenPrefix(words.back().text)) {
+    words.back().hyphenJoinNext = true;
+  }
+}
+
+void expandHyphenJoinRange(const std::vector<PageWordHit>& words, const size_t index, size_t& lo, size_t& hi) {
+  if (words.empty() || index >= words.size()) {
+    lo = 0;
+    hi = 0;
+    return;
+  }
+  lo = index;
+  hi = index;
+  while (lo > 0 && words[lo].hyphenJoinPrev) {
+    --lo;
+  }
+  while (hi + 1 < words.size() && words[hi].hyphenJoinNext) {
+    ++hi;
+  }
+}
+
+std::string joinedHyphenRangeText(const std::vector<PageWordHit>& words, const size_t lo, const size_t hi,
+                                  const bool keepLineBreakHyphen) {
+  std::string out;
+  if (words.empty() || lo > hi) {
+    return out;
+  }
+  for (size_t i = lo; i <= hi && i < words.size(); ++i) {
+    std::string token = words[i].text;
+    const bool joinToNext = i < hi && words[i].hyphenJoinNext;
+    if (!keepLineBreakHyphen && joinToNext && !token.empty() && token.back() == '-') {
+      token.pop_back();
+    }
+    if (i > lo && !(i > 0 && words[i - 1].hyphenJoinNext)) {
+      out += ' ';
+    }
+    out += token;
+  }
+  return out;
 }

--- a/lib/Epub/Epub/PageWordIndex.h
+++ b/lib/Epub/Epub/PageWordIndex.h
@@ -20,6 +20,10 @@ struct PageWordHit {
   int fontId = 0;
   std::string text;
   bool isDropCap = false;
+  /** Line-wrap hyphenation: this token ends with '-' and the next token is the rest of the same word. */
+  bool hyphenJoinNext = false;
+  /** This token continues a previous hyphen-broken token. */
+  bool hyphenJoinPrev = false;
 };
 
 /**
@@ -29,3 +33,17 @@ struct PageWordHit {
 void buildPageWordIndex(const Page& page, GfxRenderer& renderer, int bodyFontId, int headerFontId, int marginLeft,
                         int marginTop, std::vector<PageWordHit>& out, std::vector<size_t>* lineStartsOut = nullptr,
                         bool omitStoredWordStrings = false);
+
+/** True when @p text looks like a hyphenation prefix at a line wrap (letter, then ASCII '-'). */
+bool isLineBreakHyphenPrefix(const std::string& text);
+
+/** Sets hyphenJoinNext / hyphenJoinPrev for same-page line wraps. Last-word prefixes also get
+ *  hyphenJoinNext so a following page can continue the word. */
+void markHyphenJoins(std::vector<PageWordHit>& words);
+
+/** Inclusive token range around @p index that belongs to the same hyphen-broken word. */
+void expandHyphenJoinRange(const std::vector<PageWordHit>& words, size_t index, size_t& lo, size_t& hi);
+
+/** Joins tokens in [lo, hi]. Line-break hyphens are dropped unless @p keepLineBreakHyphen. */
+std::string joinedHyphenRangeText(const std::vector<PageWordHit>& words, size_t lo, size_t hi,
+                                  bool keepLineBreakHyphen);

--- a/src/activity/reader/Epub/EpubDictionaryUi.cpp
+++ b/src/activity/reader/Epub/EpubDictionaryUi.cpp
@@ -15,6 +15,7 @@
 #include "state/SavedDictionaryWords.h"
 #include "state/ReaderSetting.h"
 #include "state/SystemSetting.h"
+#include "system/FontManager.h"
 #include "system/Fonts.h"
 #include "system/MappedInputManager.h"
 
@@ -47,6 +48,25 @@ std::string stripSurroundingPunctuation(const std::string& s) {
 }  // namespace
 
 EpubDictionaryUi::EpubDictionaryUi() = default;
+
+bool EpubDictionaryUi::fillWordsForPage(EpubActivity& act, const int spine, const int page,
+                                        std::vector<PageWordHit>& out) const {
+  out.clear();
+  if (!act.epub) {
+    return false;
+  }
+  auto pageObj = Section::loadCachedPage(act.epub->getCachePath(), spine, page);
+  if (!pageObj) {
+    return false;
+  }
+  const ViewportInfo info = act.calculateViewport();
+  const int fontId = act.bookSettings.getReaderFontId();
+  const int headerFontId = FontManager::getNextFont(fontId);
+  buildPageWordIndex(*pageObj, act.renderer, fontId, headerFontId, info.totalMarginLeft, info.totalMarginTop, out,
+                     nullptr, false);
+  markHyphenJoins(out);
+  return !out.empty();
+}
 
 void EpubDictionaryUi::tryChordEnter(EpubActivity& act) {
   if (!act.epub || !act.section || mode_) {
@@ -96,6 +116,7 @@ void EpubDictionaryUi::prepareWordGeometry(EpubActivity& act) {
   }
   constexpr bool omitStoredWordStrings = false;
   buildPageWordIndex(*page, act.renderer, fontId, headerFontId, ml, mt, words_, &lineFirst_, omitStoredWordStrings);
+  markHyphenJoins(words_);
 }
 
 void EpubDictionaryUi::captureFramebuffer(EpubActivity& act) {
@@ -231,11 +252,56 @@ void EpubDictionaryUi::ensureDictionaryOpen() {
   Serial.printf("[%lu] [DICT] ensureDictionaryOpen: open('%s') -> %d\n", millis(), folder.c_str(), opened ? 1 : 0);
 }
 
+std::string EpubDictionaryUi::dictionaryQueryFromFocus(EpubActivity& act, const bool keepLineBreakHyphen) {
+  if (words_.empty() || focus_ >= words_.size()) {
+    return {};
+  }
+  size_t lo = focus_;
+  size_t hi = focus_;
+  expandHyphenJoinRange(words_, focus_, lo, hi);
+  std::string text = joinedHyphenRangeText(words_, lo, hi, keepLineBreakHyphen);
+
+  if (lo == 0 && act.epub && act.section && act.section->currentPage > 0) {
+    std::vector<PageWordHit> prev;
+    if (fillWordsForPage(act, act.currentSpineIndex, act.section->currentPage - 1, prev) && !prev.empty() &&
+        prev.back().hyphenJoinNext) {
+      size_t plo = 0;
+      size_t phi = 0;
+      expandHyphenJoinRange(prev, prev.size() - 1, plo, phi);
+      std::string prefix = joinedHyphenRangeText(prev, plo, phi, keepLineBreakHyphen);
+      if (!keepLineBreakHyphen && !prefix.empty() && prefix.back() == '-') {
+        prefix.pop_back();
+      }
+      text = prefix + text;
+    }
+  }
+
+  if (hi + 1 == words_.size() && words_.back().hyphenJoinNext && act.epub && act.section) {
+    std::vector<PageWordHit> next;
+    bool haveNext = fillWordsForPage(act, act.currentSpineIndex, act.section->currentPage + 1, next);
+    if (!haveNext && act.currentSpineIndex + 1 < act.epub->getSpineItemsCount()) {
+      haveNext = fillWordsForPage(act, act.currentSpineIndex + 1, 0, next);
+    }
+    if (haveNext && !next.empty()) {
+      size_t nlo = 0;
+      size_t nhi = 0;
+      expandHyphenJoinRange(next, 0, nlo, nhi);
+      const std::string suffix = joinedHyphenRangeText(next, nlo, nhi, keepLineBreakHyphen);
+      if (!keepLineBreakHyphen && !text.empty() && text.back() == '-') {
+        text.pop_back();
+      }
+      text += suffix;
+    }
+  }
+  return text;
+}
+
 void EpubDictionaryUi::performLookup(EpubActivity& act) {
   if (words_.empty() || focus_ >= words_.size()) {
     return;
   }
-  lookedUpWord_ = stripSurroundingPunctuation(words_[focus_].text);
+  lookedUpWord_ = stripSurroundingPunctuation(dictionaryQueryFromFocus(act, false));
+  const std::string keptHyphen = stripSurroundingPunctuation(dictionaryQueryFromFocus(act, true));
   currentDefinition_.clear();
   definitionScrollLine_ = 0;
   wordAlreadySaved_ = !lookedUpWord_.empty() && SAVED_WORDS.contains(lookedUpWord_);
@@ -254,7 +320,9 @@ void EpubDictionaryUi::performLookup(EpubActivity& act) {
     ensureDictionaryOpen();
     if (!dict_.isOpen()) {
       currentDefinition_ = "Could not open the selected dictionary.";
-    } else if (!dict_.lookup(lookedUpWord_, currentDefinition_, &truncated)) {
+    } else if (!dict_.lookup(lookedUpWord_, currentDefinition_, &truncated) &&
+               (keptHyphen.empty() || keptHyphen == lookedUpWord_ ||
+                !dict_.lookup(keptHyphen, currentDefinition_, &truncated))) {
       currentDefinition_ = "No definition found.";
     }
   }
@@ -504,9 +572,14 @@ void EpubDictionaryUi::drawFocusHighlight(EpubActivity& act) {
   if (words_.empty() || focus_ >= words_.size()) {
     return;
   }
-  const PageWordHit& w = words_[focus_];
-  act.renderer.ui.fillSparseInkLatticeInRect(w.screenX, std::max(0, w.screenY), std::max(1, w.screenW),
-                                             std::max(3, w.screenH), kHighlightLatticeStepPx);
+  size_t lo = focus_;
+  size_t hi = focus_;
+  expandHyphenJoinRange(words_, focus_, lo, hi);
+  for (size_t i = lo; i <= hi && i < words_.size(); ++i) {
+    const PageWordHit& w = words_[i];
+    act.renderer.ui.fillSparseInkLatticeInRect(w.screenX, std::max(0, w.screenY), std::max(1, w.screenW),
+                                               std::max(3, w.screenH), kHighlightLatticeStepPx);
+  }
 }
 
 void EpubDictionaryUi::drawDefinitionPanel(EpubActivity& act) {

--- a/src/activity/reader/Epub/EpubDictionaryUi.h
+++ b/src/activity/reader/Epub/EpubDictionaryUi.h
@@ -41,6 +41,8 @@ class EpubDictionaryUi {
   void drawFocusHighlight(EpubActivity& act);
   void drawDefinitionPanel(EpubActivity& act);
   void performLookup(EpubActivity& act);
+  std::string dictionaryQueryFromFocus(EpubActivity& act, bool keepLineBreakHyphen);
+  bool fillWordsForPage(EpubActivity& act, int spine, int page, std::vector<PageWordHit>& out) const;
   void ensureDictionaryOpen();
   void saveCurrentWord(EpubActivity& act);
   /** Actually releases currentDefinition_/definitionBlocks_/definitionLines_'s heap capacity (not


### PR DESCRIPTION
Hyphenation at a line break stored `some-` and `thing` as two word hits. Dictionary focus highlighted only the first fragment and looked up a truncated string, so StarDict missed.

After building the page word index, adjacent hyphen-wrap tokens are marked as one word. Focus highlights the whole range, and lookup joins them (and the leftover piece on the previous/next page when the wrap crosses a page break). A second try keeps the hyphen for dictionaries that index the hyphenated form.

## Test on device
- Find a hyphen at the end of a line, enter dictionary, land on that fragment
- Highlight should cover both halves; lookup should be the full word
- Same when the hyphen is the last word on the page and the rest is on the next page

Made with [Cursor](https://cursor.com)