### PR TITLE
Drop CPU to 10 MHz while the reader sits idle between page turns

### DIFF
--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -1,0 +1,34 @@
+#include "HalPowerManager.h"
+
+#include <WiFi.h>
+
+HalPowerManager powerManager;
+
+void HalPowerManager::begin() {
+  normalFreq = static_cast<int>(getCpuFrequencyMhz());
+  if (normalFreq <= 0) {
+    normalFreq = 160;
+  }
+}
+
+void HalPowerManager::setPowerSaving(bool enabled) {
+  if (normalFreq <= 0) {
+    return;
+  }
+
+  if (WiFi.getMode() != WIFI_MODE_NULL) {
+    enabled = false;
+  }
+
+  if (enabled && !isLowPower) {
+    if (!setCpuFrequencyMhz(LOW_POWER_FREQ)) {
+      return;
+    }
+    isLowPower = true;
+  } else if (!enabled && isLowPower) {
+    if (!setCpuFrequencyMhz(normalFreq)) {
+      return;
+    }
+    isLowPower = false;
+  }
+}

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Arduino.h>
+
+class HalPowerManager {
+  int normalFreq = 0;
+  bool isLowPower = false;
+
+ public:
+  static constexpr int LOW_POWER_FREQ = 10;
+  static constexpr unsigned long IDLE_POWER_SAVING_MS = 3000;
+
+  void begin();
+  void setPowerSaving(bool enabled);
+};
+
+extern HalPowerManager powerManager;

--- a/src/activity/page/RecentActivity.cpp
+++ b/src/activity/page/RecentActivity.cpp
@@ -1040,6 +1040,10 @@ std::string RecentActivity::formatTime(uint32_t milliseconds) const {
 /**
  * Main loop for handling user input and updating state.
  */
+bool RecentActivity::skipLoopDelay() {
+  return updateRequired || recentImageCacheJobPending_;
+}
+
 void RecentActivity::loop() {
   if (homeMenuDrawer_ && homeMenuDrawer_->visible()) {
     homeMenuDrawer_->handleInput(mappedInput);

--- a/src/activity/page/RecentActivity.h
+++ b/src/activity/page/RecentActivity.h
@@ -57,7 +57,7 @@ class RecentActivity final : public Activity, public Menu {
 
   static constexpr int LIST_VISIBLE_ITEMS = 5;
 
-  bool skipLoopDelay() override { return true; }
+  bool skipLoopDelay() override;
 
   /**
    * View mode enumeration for displaying recent books.

--- a/src/activity/reader/Epub/EpubActivity.h
+++ b/src/activity/reader/Epub/EpubActivity.h
@@ -86,8 +86,6 @@ class EpubActivity final : public ActivityWithSubactivity {
   void onEnter() override;
   void onExit() override;
   void loop() override;
-  /** Match Crosspoint-style reader: pump display from loop (no separate FreeRTOS render task). */
-  bool skipLoopDelay() override { return true; }
   /** X3 flick/shake page turns never register as button activity, so with auto-sleep on the device would
    *  fall asleep mid-read; suppress the idle timeout in-book while that gesture is enabled. */
   bool preventAutoSleep() override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include <GfxRenderer.h>
 #include <HalDisplay.h>
 #include <HalGPIO.h>
+#include <HalPowerManager.h>
 #include <SDCardManager.h>
 #include <SPI.h>
 
@@ -273,12 +274,14 @@ bool handleGlobalPowerRefresh() {
 void setup() {
   t1 = millis();
   gpio.begin();
+  powerManager.begin();
   setupDisplayAndFonts();
 
   if (gpio.isUsbConnected()) {
     Serial.begin(115200);
-    unsigned long start = millis();
-    while (!Serial && (millis() - start) < 3000) delay(10);
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+    Serial.setTxTimeoutMs(0);
+#endif
   }
 
   sdCardAvailable = SdMan.begin();
@@ -295,7 +298,8 @@ void setup() {
       verifyPowerButtonDuration();
       break;
     case HalGPIO::WakeupReason::AfterUSBPower:
-      gpio.startDeepSleep();
+      // USB still plugged in after a flash looks like this. Sleeping here leaves the
+      // last e-ink frame frozen and makes power look dead until a hold-wake.
       break;
     default:
       break;
@@ -311,8 +315,13 @@ void setup() {
 void loop() {
   gpio.update();
   static unsigned long lastActivityTime = millis();
+  static unsigned long lastInputTime = millis();
 
-  if (gpio.wasAnyPressed() || gpio.wasAnyReleased() || (currentActivity && currentActivity->preventAutoSleep())) {
+  if (gpio.wasAnyPressed() || gpio.wasAnyReleased()) {
+    lastActivityTime = millis();
+    lastInputTime = millis();
+    powerManager.setPowerSaving(false);
+  } else if (currentActivity && currentActivity->preventAutoSleep()) {
     lastActivityTime = millis();
   }
 
@@ -336,7 +345,11 @@ void loop() {
   }
 
   if (currentActivity && currentActivity->skipLoopDelay()) {
+    powerManager.setPowerSaving(false);
     yield();
+  } else if (millis() - lastInputTime >= HalPowerManager::IDLE_POWER_SAVING_MS) {
+    powerManager.setPowerSaving(true);
+    delay(50);
   } else {
     delay(10);
   }

--- a/src/simulator/HalPowerManager.h
+++ b/src/simulator/HalPowerManager.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifdef SIMULATOR
+
+class HalPowerManager {
+ public:
+  static constexpr unsigned long IDLE_POWER_SAVING_MS = 3000;
+  void begin() {}
+  void setPowerSaving(bool) {}
+};
+
+inline HalPowerManager powerManager;
+
+#endif


### PR DESCRIPTION
EpubActivity returned `skipLoopDelay() == true`, so `loop()` spun at 160 MHz with only `yield()` even while the page sat still. Home did the same. That is the main idle current on this chip.

After 3s with no button activity the CPU drops to 10 MHz and the loop uses `delay(50)`. Any press, or an activity that still needs a tight loop (Wi‑Fi, home image-cache job), brings 160 MHz back. Wi‑Fi already up stays at full clock. USB-after-flash no longer calls `startDeepSleep()`, which left the last e-ink frame frozen and looked like a dead boot. Serial also skips the 3s wait-for-monitor.

## Test on device
- Turn a page: still snappy, then after a few seconds idle the chip should run cooler / draw less
- Home cover cache should still finish; then idle downclock
- Open hotspot / local network: stays full speed while the server runs
- Flash over USB and let it reboot without unplugging: should show boot UI, not a frozen last frame

Made with [Cursor](https://cursor.com)