### PR TITLE
Open highlights and bookmarks from Home, and call them Highlights

### DIFF
--- a/src/activity/page/components/recent/HomeMenuDrawer.ipp
+++ b/src/activity/page/components/recent/HomeMenuDrawer.ipp
@@ -1,7 +1,7 @@
 namespace {
 constexpr int kHomeDrawerRowH = UiTheme::DRAWER_LIST_ITEM_HEIGHT;
 constexpr int kHomeDrawerMainRowH = UiTheme::DRAWER_LIST_ITEM_HEIGHT;
-constexpr int kHomeDrawerMainRowCount = 5;  // Recents, Bookmarks, Annotations, Dictionary, Favorites
+constexpr int kHomeDrawerMainRowCount = 5;  // Recents, Bookmarks, Highlights, Dictionary, Favorites
 constexpr int kHomeDrawerHeaderFont = ATKINSON_HYPERLEGIBLE_14_FONT_ID;
 constexpr int kHomeDrawerPageHeaderExtraH = 14;
 constexpr int kHomeDrawerPadX = 20;
@@ -138,12 +138,28 @@ class RecentActivity::HomeMenuDrawer {
         render(HalDisplay::FAST_REFRESH);
         return;
       }
+      if (mode_ == HomeDrawerMode::AnnotationDetail) {
+        mode_ = HomeDrawerMode::Annotations;
+        render(HalDisplay::FAST_REFRESH);
+        return;
+      }
+      if (mode_ == HomeDrawerMode::BookmarkDetail) {
+        mode_ = HomeDrawerMode::Bookmarks;
+        render(HalDisplay::FAST_REFRESH);
+        return;
+      }
       hide();
       return;
     }
 
-    if (mode_ == HomeDrawerMode::BookmarkDetail || mode_ == HomeDrawerMode::AnnotationDetail ||
-        mode_ == HomeDrawerMode::DictionaryDetail) {
+    if (mode_ == HomeDrawerMode::BookmarkDetail || mode_ == HomeDrawerMode::AnnotationDetail) {
+      if (input.wasReleased(MappedInputManager::Button::Confirm)) {
+        openSelectedNoteInBook();
+      }
+      return;
+    }
+
+    if (mode_ == HomeDrawerMode::DictionaryDetail) {
       return;
     }
 
@@ -284,6 +300,7 @@ class RecentActivity::HomeMenuDrawer {
     int actionId = -1;
     int spine = -1;
     int page = -1;
+    uint32_t timestamp = 0;
   };
 
   RecentActivity& owner_;
@@ -353,7 +370,7 @@ class RecentActivity::HomeMenuDrawer {
       case HomeDrawerMode::Bookmarks:
         return "Bookmarks";
       case HomeDrawerMode::Annotations:
-        return "Annotations";
+        return "Highlights";
       case HomeDrawerMode::Dictionary:
         return "Dictionary";
       case HomeDrawerMode::DictionaryDeleteConfirm:
@@ -361,7 +378,7 @@ class RecentActivity::HomeMenuDrawer {
       case HomeDrawerMode::BookmarkDetail:
         return "Bookmark";
       case HomeDrawerMode::AnnotationDetail:
-        return "Annotation";
+        return "Highlight";
       case HomeDrawerMode::DictionaryDetail:
         return dictionaryDetailWord_.empty() ? "Definition" : dictionaryDetailWord_.c_str();
       case HomeDrawerMode::Main:
@@ -384,7 +401,7 @@ class RecentActivity::HomeMenuDrawer {
       case 1:
         return "Bookmarks";
       case 2:
-        return "Annotations";
+        return "Highlights";
       case 3:
         return "Dictionary";
       case 4:
@@ -416,7 +433,7 @@ class RecentActivity::HomeMenuDrawer {
                           : mode_ == HomeDrawerMode::RecentsActions ? "No book options"
                           : mode_ == HomeDrawerMode::Favorites      ? "No favorites"
                           : mode_ == HomeDrawerMode::Bookmarks      ? "No bookmarks"
-                          : mode_ == HomeDrawerMode::Annotations    ? "No annotations"
+                          : mode_ == HomeDrawerMode::Annotations    ? "No highlights"
                           : mode_ == HomeDrawerMode::Dictionary     ? "No saved words"
                                                                     : "";
       const int msgY = drawerY_ + headerHeight() + 42;
@@ -629,6 +646,12 @@ class RecentActivity::HomeMenuDrawer {
 
   void drawHints() {
     const auto labels = owner_.mappedInput.mapLabels("Back", "Select", "Up", "");
+    if (mode_ == HomeDrawerMode::AnnotationDetail || mode_ == HomeDrawerMode::BookmarkDetail) {
+      const auto openLabels = owner_.mappedInput.mapLabels("Back", "Open", "", "");
+      renderer_.ui.buttonHints(ATKINSON_HYPERLEGIBLE_10_FONT_ID, openLabels.btn1, openLabels.btn2, openLabels.btn3,
+                               openLabels.btn4);
+      return;
+    }
     if (mode_ == HomeDrawerMode::Recents || mode_ == HomeDrawerMode::Dictionary) {
       const auto recentLabels = owner_.mappedInput.mapLabels("Back", "Select", "Remove", "");
       renderer_.ui.buttonHints(ATKINSON_HYPERLEGIBLE_10_FONT_ID, recentLabels.btn1, recentLabels.btn2,
@@ -655,7 +678,7 @@ class RecentActivity::HomeMenuDrawer {
         loadBookmarks();
         mode_ = HomeDrawerMode::Bookmarks;
       } else if (selected_ == 2) {
-        renderLoading("Annotations", "Loading Annotations");
+        renderLoading("Highlights", "Loading Highlights");
         loadAnnotations();
         mode_ = HomeDrawerMode::Annotations;
       } else if (selected_ == 3) {
@@ -1126,6 +1149,56 @@ class RecentActivity::HomeMenuDrawer {
     owner_.openBookPath(row.bookPath, row.bookTitle, row.bookAuthor, true);
   }
 
+  void fillBookIdentity(DrawerRow& row, const std::string& cachePath) {
+    row.cachePath = cachePath;
+    const RecentBook* recent = findRecentBookByCachePath(cachePath);
+    if (!recent) {
+      return;
+    }
+    row.bookPath = recent->path;
+    row.bookTitle = bookDisplayTitle(*recent);
+    row.bookAuthor = recent->author;
+  }
+
+  void openSelectedNoteInBook() {
+    if (selected_ < 0 || selected_ >= static_cast<int>(rows_.size())) {
+      return;
+    }
+    const DrawerRow& row = rows_[selected_];
+    if (row.cachePath.empty() || row.spine < 0 || row.page < 0) {
+      return;
+    }
+
+    BookProgress::Data data{};
+    BookProgress progress(row.cachePath);
+    (void)progress.load(data);
+    data.spineIndex = static_cast<uint16_t>(row.spine);
+    data.pageNumber = static_cast<uint16_t>(row.page);
+    data.lastReadTimestamp = millis();
+    progress.save(data);
+
+    std::string path = row.bookPath;
+    std::string title = row.bookTitle;
+    std::string author = row.bookAuthor;
+    if (path.empty()) {
+      const RecentBook* recent = findRecentBookByCachePath(row.cachePath);
+      if (recent) {
+        path = recent->path;
+        if (title.empty()) {
+          title = bookDisplayTitle(*recent);
+        }
+        if (author.empty()) {
+          author = recent->author;
+        }
+      }
+    }
+    if (path.empty()) {
+      return;
+    }
+    hide();
+    owner_.openBookPath(path, title, author, true);
+  }
+
   void loadBookmarks() {
     rows_.clear();
     const std::vector<std::string> caches = epubCacheDirs();
@@ -1150,9 +1223,10 @@ class RecentActivity::HomeMenuDrawer {
         char pageLabel[24];
         std::snprintf(pageLabel, sizeof(pageLabel), " p%d", static_cast<int>(b.pageNumber) + 1);
         row.label = bookTitle + " - " + std::string(b.chapterTitle) + pageLabel;
-        row.cachePath = cachePath;
+        fillBookIdentity(row, cachePath);
         row.spine = b.spineIndex;
         row.page = b.pageNumber;
+        row.timestamp = b.timestamp;
         rows_.push_back(std::move(row));
       }
       f.close();
@@ -1181,12 +1255,16 @@ class RecentActivity::HomeMenuDrawer {
           const std::string text = trimDrawerText(rec.text);
           row.label = text.empty() ? titleForCachePath(cachePath) : text;
           row.sublabel = text;
-          row.cachePath = cachePath;
+          fillBookIdentity(row, cachePath);
           row.spine = spine;
           row.page = page;
+          row.timestamp = rec.timestamp;
           rows_.push_back(std::move(row));
         }
       }
     }
+    std::stable_sort(rows_.begin(), rows_.end(), [](const DrawerRow& a, const DrawerRow& b) {
+      return a.timestamp > b.timestamp;
+    });
   }
 };

--- a/src/activity/reader/Epub/MenuDrawer.cpp
+++ b/src/activity/reader/Epub/MenuDrawer.cpp
@@ -113,7 +113,7 @@ MenuDrawer::MenuDrawer(GfxRenderer& renderer, ActionCallback onAction, DismissCa
   menuItems.push_back({"Apply Preset", MenuAction::APPLY_PRESET});
   menuItems.push_back({"Go To Percent", MenuAction::GO_TO_PERCENT});
   menuItems.push_back({"Show Bookmarks", MenuAction::SHOW_BOOKMARKS});
-  menuItems.push_back({"Annotations", MenuAction::SHOW_ANNOTATIONS});
+  menuItems.push_back({"Highlights", MenuAction::SHOW_ANNOTATIONS});
   menuItems.push_back({"Dictionary", MenuAction::ENTER_DICTIONARY});
   menuItems.push_back({"KOReader Sync", MenuAction::KOREADER_SYNC});
   menuItems.push_back({"Delete Cache", MenuAction::DELETE_CACHE});
@@ -679,7 +679,7 @@ void MenuDrawer::renderAnnotations() {
 
   const int headerH = drawerHeaderHeight();
   const int headerY = tocDrawerY + (headerH - renderer.text.getLineHeight(ATKINSON_HYPERLEGIBLE_12_FONT_ID)) / 2;
-  renderer.text.render(ATKINSON_HYPERLEGIBLE_12_FONT_ID, tocDrawerX + 20, headerY, "Annotations", true,
+  renderer.text.render(ATKINSON_HYPERLEGIBLE_12_FONT_ID, tocDrawerX + 20, headerY, "Highlights", true,
                        EpdFontFamily::BOLD);
 
   const int dividerY = tocDrawerY + headerH;
@@ -688,7 +688,7 @@ void MenuDrawer::renderAnnotations() {
   if (totalItems == 0) {
     const char* line1 = "No highlights yet";
     const char* line2 = "Front right + side Down/Right";
-    const char* line3 = "to start annotating.";
+    const char* line3 = "to start highlighting.";
     const int lh = renderer.text.getLineHeight(ATKINSON_HYPERLEGIBLE_10_FONT_ID);
     const int subLh = renderer.text.getLineHeight(ATKINSON_HYPERLEGIBLE_8_FONT_ID);
     const int msgY = dividerY + 48;


### PR DESCRIPTION
The Home drawer listed bookmarks and annotations but Confirm on the detail screen did nothing, so you could not jump back into the book. The in-book menu still said Annotations while Home and the empty state talked about highlights.

Confirm on a bookmark or highlight detail now writes that spine/page into BookProgress and opens the book. Labels are Highlights everywhere in those two drawers.

## Test on device
- Home → Bookmarks → open one → lands on that page
- Home → Highlights → open one → lands on that page
- In-book menu item and empty-state copy say Highlights
- Back from detail returns to the list, not all the way out of the drawer

Made with [Cursor](https://cursor.com)